### PR TITLE
Add apiBase to autocomplete model

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,8 @@ NEW_TAB_AUTOCOMPLETE_MODEL=$(cat <<EOF
     "title": "stacklok-hosted",
     "provider": "vllm",
     "model": "Qwen/Qwen2.5-Coder-14B-Instruct",
-    "apiKey": ""
+    "apiKey": "",
+    "apiBase": "http://localhost:8989/vllm"
 }
 EOF
 )


### PR DESCRIPTION
This is needed for JetBrains IDEs. 

Without this, the prompt will hang forever and the logs will show this message:

```
[info] Starting Continue core...
[2024-11-18T09:57:36] [info] Starting Continue core... 
[2024-11-18T09:57:36] Setup 
[2024-11-18T09:57:36] Core started 
[2024-11-18T09:57:37] HTTP 401 Unauthorized from https://api.openai.com/v1/models

{
  "error": {
    "message": "Incorrect API key provided: stlk_033*********************************************************1b9a. You can find your API key at https://platform.openai.com/account/api-keys.",
    "type": "invalid_request_error",
    "param": null,
    "code": "invalid_api_key"
  }
}

Code: undefined
Error number: undefined
Syscall: undefined
Type: undefined

Error: HTTP 401 Unauthorized from https://api.openai.com/v1/models

{
  "error": {
    "message": "Incorrect API key provided: stlk_033*********************************************************1b9a. You can find your API key at https://platform.openai.com/account/api-keys.",
    "type": "invalid_request_error",
    "param": null,
    "code": "invalid_api_key"
  }
}
    at customFetch (/snapshot/continue/binary/out/index.js:471442:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async withExponentialBackoff (/snapshot/continue/binary/out/index.js:471175:22) 
```
