### PR TITLE
requires-python was breaking make test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ description = "Generative AI CodeGen security gateway"
 readme = "README.md"
 authors = []
 packages = [{include = "codegate", from = "src"}]
-requires-python = ">=3.11"
 
 [tool.poetry.dependencies]
 python = ">=3.11"


### PR DESCRIPTION
I wasn't sure what requires-python does, but we do have another explicit python dependency and I was getting an error with that line:
```
The Poetry configuration is invalid:
  - Additional properties are not allowed ('requires-python' was unexpected)
```
