### PR TITLE
Include .gitattributes file for git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gguf filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Include the file so we don't have to do `git lfs track`