### PR TITLE
Update llama.cpp related code to use openai format

### DIFF
--- a/src/codegate/config.py
+++ b/src/codegate/config.py
@@ -28,7 +28,7 @@ class Config:
     log_format: LogFormat = LogFormat.JSON
     prompts: PromptConfig = field(default_factory=PromptConfig)
 
-    chat_model_path: str = "./models/qwen2.5-coder-1.5b-instruct-q5_k_m.gguf"
+    model_base_path: str = "./models"
     chat_model_n_ctx: int = 32768
     chat_model_n_gpu_layers: int = -1
 
@@ -102,7 +102,7 @@ class Config:
                 host=config_data.get("host", cls.host),
                 log_level=config_data.get("log_level", cls.log_level.value),
                 log_format=config_data.get("log_format", cls.log_format.value),
-                chat_model_path=config_data.get("chat_model_path", cls.chat_model_path),
+                model_base_path=config_data.get("chat_model_path", cls.model_base_path),
                 chat_model_n_ctx=config_data.get(
                     "chat_model_n_ctx", cls.chat_model_n_ctx
                 ),

--- a/src/codegate/inference/inference_engine.py
+++ b/src/codegate/inference/inference_engine.py
@@ -46,6 +46,15 @@ class LlamaCppInferenceEngine:
 
         return self.__models[model_path]
 
+    async def complete(self, model_path, n_ctx=512, n_gpu_layers=0, **completion_request):
+        """
+        Generates a chat completion using the specified model and request parameters.
+        """
+        model = await self.__get_model(
+            model_path=model_path, n_ctx=n_ctx, n_gpu_layers=n_gpu_layers
+        )
+        return model.create_completion(**completion_request)
+
     async def chat(self, model_path, n_ctx=512, n_gpu_layers=0, **chat_completion_request):
         """
         Generates a chat completion using the specified model and request parameters.
@@ -53,7 +62,7 @@ class LlamaCppInferenceEngine:
         model = await self.__get_model(
             model_path=model_path, n_ctx=n_ctx, n_gpu_layers=n_gpu_layers
         )
-        return model.create_completion(**chat_completion_request)
+        return model.create_chat_completion(**chat_completion_request)
 
     async def embed(self, model_path, content):
         """

--- a/src/codegate/providers/litellmshim/generators.py
+++ b/src/codegate/providers/litellmshim/generators.py
@@ -47,7 +47,6 @@ async def llamacpp_stream_generator(stream: Iterator[Any]) -> AsyncIterator[str]
             if hasattr(chunk, "model_dump_json"):
                 chunk = chunk.model_dump_json(exclude_none=True, exclude_unset=True)
             try:
-                chunk["content"] = chunk["choices"][0]["text"]
                 yield f"data:{json.dumps(chunk)}\n\n"
                 await asyncio.sleep(0)
             except Exception as e:

--- a/src/codegate/providers/llamacpp/completion_handler.py
+++ b/src/codegate/providers/llamacpp/completion_handler.py
@@ -20,10 +20,6 @@ class LlamaCppCompletionHandler(BaseCompletionHandler):
         if completion_request is None:
             raise Exception("Couldn't translate the request")
 
-        # Replace n_predict option with max_tokens
-        if 'n_predict' in completion_request:
-            completion_request['max_tokens'] = completion_request['n_predict']
-            del completion_request['n_predict']
         return ChatCompletionRequest(**completion_request)
 
     def translate_streaming_response(
@@ -50,12 +46,20 @@ class LlamaCppCompletionHandler(BaseCompletionHandler):
             stream: bool = False
     ) -> Union[ModelResponse, AsyncIterator[ModelResponse]]:
         """
-        Execute the completion request with LiteLLM's API
+        Execute the completion request with inference engine API
         """
-        response = await self.inference_engine.chat(Config.get_config().chat_model_path,
-                                                    Config.get_config().chat_model_n_ctx,
-                                                    Config.get_config().chat_model_n_gpu_layers,
-                                                    **request)
+        model_path = f"{Config.get_config().model_base_path}/{request['model']}.gguf"
+
+        if 'prompt' in request:
+            response = await self.inference_engine.complete(model_path,
+                                                        Config.get_config().chat_model_n_ctx,
+                                                        Config.get_config().chat_model_n_gpu_layers,
+                                                        **request)
+        else:
+            response = await self.inference_engine.chat(model_path,
+                                                        Config.get_config().chat_model_n_ctx,
+                                                        Config.get_config().chat_model_n_gpu_layers,
+                                                        **request)
         return response
 
     def create_streaming_response(

--- a/src/codegate/providers/llamacpp/provider.py
+++ b/src/codegate/providers/llamacpp/provider.py
@@ -19,11 +19,11 @@ class LlamaCppProvider(BaseProvider):
 
     def _setup_routes(self):
         """
-        Sets up the /chat route for the provider as expected by the
-        Llama API. Extracts the API key from the "Authorization" header and
-        passes it to the completion handler.
+        Sets up the /completions and /chat/completions routes for the
+        provider as expected by the Llama API.
         """
-        @self.router.post(f"/{self.provider_route_name}/completion")
+        @self.router.post(f"/{self.provider_route_name}/completions")
+        @self.router.post(f"/{self.provider_route_name}/chat/completions")
         async def create_completion(
             request: Request,
         ):


### PR DESCRIPTION
This PR modifies the llama.cpp related implementation to use openai format request/response. 

It assumes that Continue plugin is configured as follows.

```
"models": [
...
  {
      "title": "Llama CPP",
      "provider": "openai",
      "model": "qwen2.5-coder-1.5b-instruct-q5_k_m",
      "apiBase": "http://localhost:8989/llamacpp"
  },
...
],
...
"tabAutocompleteModel": {
    "title": "Llama CPP",
    "provider": "openai",
    "model": "qwen2.5-coder-1.5b-instruct-q5_k_m",
    "apiBase": "http://localhost:8989/llamacpp",
},
...
```