### PR TITLE
Normalize and denormalize llamacpp streaming reply

### DIFF
--- a/src/codegate/pipeline/codegate_system_prompt/codegate.py
+++ b/src/codegate/pipeline/codegate_system_prompt/codegate.py
@@ -17,8 +17,7 @@ class CodegateSystemPrompt(PipelineStep):
 
     def __init__(self, system_prompt_message: Optional[str] = None):
         self._system_message = ChatCompletionSystemMessage(
-            content=system_prompt_message,
-            role="system"
+            content=system_prompt_message, role="system"
         )
 
     @property
@@ -29,7 +28,7 @@ class CodegateSystemPrompt(PipelineStep):
         return "codegate-system-prompt"
 
     async def process(
-            self, request: ChatCompletionRequest, context: PipelineContext
+        self, request: ChatCompletionRequest, context: PipelineContext
     ) -> PipelineResult:
         """
         Process the completion request and add a system prompt if the user message contains

--- a/src/codegate/providers/litellmshim/generators.py
+++ b/src/codegate/providers/litellmshim/generators.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 from typing import Any, AsyncIterator
 

--- a/src/codegate/providers/llamacpp/normalizer.py
+++ b/src/codegate/providers/llamacpp/normalizer.py
@@ -1,6 +1,13 @@
-from typing import Any, AsyncIterable, AsyncIterator, Dict, Iterable, Iterator, Union
+from typing import Any, AsyncIterable, AsyncIterator, Dict, Union
 
 from litellm import ChatCompletionRequest, ModelResponse
+from litellm.types.utils import Delta, StreamingChoices
+from llama_cpp.llama_types import (
+    ChatCompletionStreamResponseChoice,
+    ChatCompletionStreamResponseDelta,
+    ChatCompletionStreamResponseDeltaEmpty,
+    CreateChatCompletionStreamResponse,
+)
 
 from codegate.providers.normalizer import ModelInputNormalizer, ModelOutputNormalizer
 
@@ -32,16 +39,97 @@ class LLamaCppInputNormalizer(ModelInputNormalizer):
         return data
 
 
+class ModelToLlamaCpp(AsyncIterator[CreateChatCompletionStreamResponse]):
+    def __init__(self, normalized_reply: AsyncIterable[ModelResponse]):
+        self.normalized_reply = normalized_reply
+        self._aiter = normalized_reply.__aiter__()
+
+    def __aiter__(self):
+        return self
+
+    @staticmethod
+    def _create_delta(
+        choice_delta: Delta,
+    ) -> Union[ChatCompletionStreamResponseDelta, ChatCompletionStreamResponseDeltaEmpty]:
+        if not choice_delta:
+            return ChatCompletionStreamResponseDeltaEmpty()
+        return ChatCompletionStreamResponseDelta(
+            content=choice_delta.content,
+            role=choice_delta.role,
+        )
+
+    async def __anext__(self) -> CreateChatCompletionStreamResponse:
+        try:
+            chunk = await self._aiter.__anext__()
+            return CreateChatCompletionStreamResponse(
+                id=chunk["id"],
+                model=chunk["model"],
+                object="chat.completion.chunk",
+                created=chunk["created"],
+                choices=[
+                    ChatCompletionStreamResponseChoice(
+                        index=choice.index,
+                        delta=self._create_delta(choice.delta),
+                        finish_reason=choice.finish_reason,
+                        logprobs=None,
+                    )
+                    for choice in chunk["choices"]
+                ],
+            )
+        except StopAsyncIteration:
+            raise StopAsyncIteration
+
+
+class LlamaCppToModel(AsyncIterator[ModelResponse]):
+    def __init__(self, normalized_reply: AsyncIterable[CreateChatCompletionStreamResponse]):
+        self.normalized_reply = normalized_reply
+        self._aiter = normalized_reply.__aiter__()
+
+    def __aiter__(self):
+        return self
+
+    @staticmethod
+    def _create_delta(
+        choice_delta: Union[
+            ChatCompletionStreamResponseDelta, ChatCompletionStreamResponseDeltaEmpty
+        ]
+    ) -> Delta:
+        if not choice_delta:  # Handles empty dict case
+            return Delta(content=None, role=None)
+        return Delta(content=choice_delta.get("content"), role=choice_delta.get("role"))
+
+    async def __anext__(self) -> ModelResponse:
+        try:
+            chunk = await self._aiter.__anext__()
+            return ModelResponse(
+                id=chunk["id"],
+                choices=[
+                    StreamingChoices(
+                        finish_reason=choice.get("finish_reason", None),
+                        index=choice["index"],
+                        delta=self._create_delta(choice.get("delta")),
+                        logprobs=None,
+                    )
+                    for choice in chunk["choices"]
+                ],
+                created=chunk["created"],
+                model=chunk["model"],
+                object=chunk["object"],
+            )
+        except StopAsyncIteration:
+            raise StopAsyncIteration
+
+
 class LLamaCppOutputNormalizer(ModelOutputNormalizer):
     def normalize_streaming(
         self,
-        model_reply: Union[AsyncIterable[Any], Iterable[Any]],
-    ) -> Union[AsyncIterator[ModelResponse], Iterator[ModelResponse]]:
+        llamacpp_stream: AsyncIterable[CreateChatCompletionStreamResponse],
+    ) -> AsyncIterator[ModelResponse]:
         """
         Normalize the output stream. This is a pass-through for liteLLM output normalizer
         as the liteLLM output is already in the normalized format.
         """
-        return model_reply
+        return LlamaCppToModel(llamacpp_stream)
 
     def normalize(self, model_reply: Any) -> ModelResponse:
         """
@@ -59,10 +147,10 @@ class LLamaCppOutputNormalizer(ModelOutputNormalizer):
 
     def denormalize_streaming(
         self,
-        normalized_reply: Union[AsyncIterable[ModelResponse], Iterable[ModelResponse]],
-    ) -> Union[AsyncIterator[Any], Iterator[Any]]:
+        model_stream: AsyncIterable[ModelResponse],
+    ) -> AsyncIterator[CreateChatCompletionStreamResponse]:
         """
         Denormalize the output stream from the completion function to the format
         expected by the client
         """
-        return normalized_reply
+        return ModelToLlamaCpp(model_stream)

--- a/src/codegate/server.py
+++ b/src/codegate/server.py
@@ -6,8 +6,6 @@ from codegate import __description__, __version__
 from codegate.config import Config
 from codegate.pipeline.base import PipelineStep, SequentialPipelineProcessor
 from codegate.pipeline.codegate_system_prompt.codegate import CodegateSystemPrompt
-from codegate.pipeline.secrets.secrets import CodegateSecrets
-from codegate.pipeline.secrets.signatures import CodegateSignatures
 from codegate.pipeline.version.version import CodegateVersion
 from codegate.providers.anthropic.provider import AnthropicProvider
 from codegate.providers.llamacpp.provider import LlamaCppProvider

--- a/tests/pipeline/codegate_system_prompt/test_codegate_system_prompt.py
+++ b/tests/pipeline/codegate_system_prompt/test_codegate_system_prompt.py
@@ -24,27 +24,22 @@ class TestCodegateSystemPrompt:
         step = CodegateSystemPrompt(system_prompt_message=test_message)
         assert step._system_message["content"] == test_message
 
-    @pytest.mark.parametrize("user_message,expected_modification", [
-        # Test cases with different scenarios
-        ("Hello CodeGate", True),
-        ("CODEGATE in uppercase", True),
-        ("No matching message", False),
-        ("codegate with lowercase", True)
-    ])
-    async def test_process_system_prompt_insertion(
-        self,
-        user_message,
-        expected_modification
-    ):
+    @pytest.mark.parametrize(
+        "user_message,expected_modification",
+        [
+            # Test cases with different scenarios
+            ("Hello CodeGate", True),
+            ("CODEGATE in uppercase", True),
+            ("No matching message", False),
+            ("codegate with lowercase", True),
+        ],
+    )
+    async def test_process_system_prompt_insertion(self, user_message, expected_modification):
         """
         Test system prompt insertion based on message content
         """
         # Prepare mock request with user message
-        mock_request = {
-            "messages": [
-                {"role": "user", "content": user_message}
-            ]
-        }
+        mock_request = {"messages": [{"role": "user", "content": user_message}]}
         mock_context = Mock(spec=PipelineContext)
 
         # Create system prompt step
@@ -52,33 +47,27 @@ class TestCodegateSystemPrompt:
         step = CodegateSystemPrompt(system_prompt_message=system_prompt)
 
         # Mock the get_last_user_message method
-        step.get_last_user_message = Mock(
-            return_value=(user_message, 0)
-        )
+        step.get_last_user_message = Mock(return_value=(user_message, 0))
 
         # Process the request
         result = await step.process(ChatCompletionRequest(**mock_request), mock_context)
 
         if expected_modification:
             # Check that system message was inserted
-            assert len(result.request['messages']) == 2
-            assert result.request['messages'][0]['role'] == 'system'
-            assert result.request['messages'][0]['content'] == system_prompt
-            assert result.request['messages'][1]['role'] == 'user'
-            assert result.request['messages'][1]['content'] == user_message
+            assert len(result.request["messages"]) == 2
+            assert result.request["messages"][0]["role"] == "system"
+            assert result.request["messages"][0]["content"] == system_prompt
+            assert result.request["messages"][1]["role"] == "user"
+            assert result.request["messages"][1]["content"] == user_message
         else:
             # Ensure no modification occurred
-            assert len(result.request['messages']) == 1
+            assert len(result.request["messages"]) == 1
 
     async def test_no_system_message_configured(self):
         """
         Test behavior when no system message is configured
         """
-        mock_request = {
-            "messages": [
-                {"role": "user", "content": "CodeGate test"}
-            ]
-        }
+        mock_request = {"messages": [{"role": "user", "content": "CodeGate test"}]}
         mock_context = Mock(spec=PipelineContext)
 
         # Create step without system message
@@ -90,10 +79,13 @@ class TestCodegateSystemPrompt:
         # Verify request remains unchanged
         assert result.request == mock_request
 
-    @pytest.mark.parametrize("edge_case", [
-        None,  # No messages
-        [],    # Empty messages list
-    ])
+    @pytest.mark.parametrize(
+        "edge_case",
+        [
+            None,  # No messages
+            [],  # Empty messages list
+        ],
+    )
     async def test_edge_cases(self, edge_case):
         """
         Test edge cases with None or empty message list

--- a/tests/providers/llamacpp/test_normalizer.py
+++ b/tests/providers/llamacpp/test_normalizer.py
@@ -1,0 +1,140 @@
+import pytest
+from litellm import ModelResponse
+from litellm.types.utils import Delta, StreamingChoices
+from llama_cpp.llama_types import CreateChatCompletionStreamResponse
+
+from codegate.providers.llamacpp.normalizer import (
+    LLamaCppOutputNormalizer,
+)
+
+
+class TestLLamaCppStreamNormalizer:
+    @pytest.mark.asyncio
+    async def test_normalize_streaming(self):
+        """
+        Test the normalize_streaming method
+        Verify conversion from llama.cpp stream to ModelResponse stream
+        """
+
+        # Mock CreateChatCompletionStreamResponse stream
+        async def mock_llamacpp_stream():
+            responses = [
+                CreateChatCompletionStreamResponse(
+                    id="test_id1",
+                    model="llama-model",
+                    object="chat.completion.chunk",
+                    created=1234567,
+                    choices=[{"index": 0, "delta": {"content": "Hello"}, "finish_reason": None}],
+                ),
+                CreateChatCompletionStreamResponse(
+                    id="test_id2",
+                    model="llama-model",
+                    object="chat.completion.chunk",
+                    created=1234568,
+                    choices=[{"index": 0, "delta": {"content": " World"}, "finish_reason": "stop"}],
+                ),
+            ]
+            for resp in responses:
+                yield resp
+
+        # Create normalizer and normalize stream
+        normalizer = LLamaCppOutputNormalizer()
+        normalized_stream = normalizer.normalize_streaming(mock_llamacpp_stream())
+
+        # Collect results
+        results = []
+        async for response in normalized_stream:
+            results.append(response)
+
+        # Assertions
+        assert len(results) == 2
+        assert all(isinstance(r, ModelResponse) for r in results)
+
+        # Check first chunk
+        assert results[0].choices[0].delta.content == "Hello"
+        assert results[0].choices[0].finish_reason is None
+
+        # Check second chunk
+        assert results[1].choices[0].delta.content == " World"
+        assert results[1].choices[0].finish_reason == "stop"
+
+    @pytest.mark.asyncio
+    async def test_denormalize_streaming(self):
+        """
+        Test the denormalize_streaming method
+        Verify conversion from ModelResponse stream to llama.cpp stream
+        """
+
+        # Mock ModelResponse stream
+        async def mock_model_response_stream():
+            responses = [
+                ModelResponse(
+                    id="test_id1",
+                    model="litellm-model",
+                    object="chat.completion",
+                    created=1234567,
+                    choices=[
+                        StreamingChoices(index=0, delta=Delta(content="Hello"), finish_reason=None)
+                    ],
+                ),
+                ModelResponse(
+                    id="test_id2",
+                    model="litellm-model",
+                    object="chat.completion",
+                    created=1234568,
+                    choices=[
+                        StreamingChoices(
+                            index=0, delta=Delta(content=" World"), finish_reason="stop"
+                        )
+                    ],
+                ),
+            ]
+            for resp in responses:
+                yield resp
+
+        # Create normalizer and denormalize stream
+        normalizer = LLamaCppOutputNormalizer()
+        denormalized_stream = normalizer.denormalize_streaming(mock_model_response_stream())
+
+        # Collect results
+        results = []
+        async for response in denormalized_stream:
+            results.append(response)
+
+        # Assertions
+        assert len(results) == 2
+
+        # Check first chunk
+        assert results[0]["choices"][0]["delta"]["content"] == "Hello"
+        assert results[0]["choices"][0]["finish_reason"] is None
+
+        # Check second chunk
+        assert results[1]["choices"][0]["delta"]["content"] == " World"
+        assert results[1]["choices"][0]["finish_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_streaming_edge_cases(self):
+        """
+        Test edge cases and error scenarios in streaming
+        """
+
+        # Empty stream
+        async def empty_stream():
+            return
+            yield
+
+        normalizer = LLamaCppOutputNormalizer()
+
+        # Test empty stream for normalize_streaming
+        normalized_empty = normalizer.normalize_streaming(empty_stream())
+        with pytest.raises(StopAsyncIteration):
+            await normalized_empty.__anext__()
+
+        # Test empty stream for denormalize_streaming
+        async def empty_model_stream():
+            return
+            yield
+
+        denormalized_empty = normalizer.denormalize_streaming(empty_model_stream())
+        with pytest.raises(StopAsyncIteration):
+            await denormalized_empty.__anext__()


### PR DESCRIPTION
At the moment we really need the denormalizer so that the blocking
pipeline can return a stream of `ModelResponse`s and the denormalizer
would convert them to the CreateChatCompletionStreamResponse structure
that is then serialized to the client. This avoids any guessing or
special casing that would otherwise be needed in the
`llamacpp_stream_generator` which currently expected
`Iterator[CreateChatCompletionStreamResponse]`.

Another change that simplifies the logic is that the
`llamacpp_stream_generator` now accepts an `AsyncIterator` instead of
just `Iterator` that the llamacpp completion hander was returning.
Again, this is to simplify the logic and pass the iterator from the
blocking pipeline. On the completion side we have a simple sync-to-async
wrapper.

Fixes: #94
