### PR TITLE
Respond with JSON if the request is non-stream

### DIFF
--- a/src/codegate/pipeline/extract_snippets/extract_snippets.py
+++ b/src/codegate/pipeline/extract_snippets/extract_snippets.py
@@ -13,6 +13,7 @@ CODE_BLOCK_PATTERN = re.compile(
 
 logger = structlog.get_logger("codegate")
 
+
 def ecosystem_from_filepath(filepath: str) -> Optional[str]:
     """
     Determine language from filepath.

--- a/src/codegate/providers/anthropic/provider.py
+++ b/src/codegate/providers/anthropic/provider.py
@@ -48,4 +48,4 @@ class AnthropicProvider(BaseProvider):
 
             is_fim_request = self._is_fim_request(request, data)
             stream = await self.complete(data, x_api_key, is_fim_request)
-            return self._completion_handler.create_streaming_response(stream)
+            return self._completion_handler.create_response(stream)

--- a/src/codegate/providers/completion/base.py
+++ b/src/codegate/providers/completion/base.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from typing import Any, AsyncIterator, Optional, Union
 
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from litellm import ChatCompletionRequest, ModelResponse
 
 
@@ -23,5 +24,17 @@ class BaseCompletionHandler(ABC):
         pass
 
     @abstractmethod
-    def create_streaming_response(self, stream: AsyncIterator[Any]) -> StreamingResponse:
+    def _create_streaming_response(self, stream: AsyncIterator[Any]) -> StreamingResponse:
         pass
+
+    @abstractmethod
+    def _create_json_response(self, response: Any) -> JSONResponse:
+        pass
+
+    def create_response(self, response: Any) -> Union[JSONResponse, StreamingResponse]:
+        """
+        Create a FastAPI response from the completion response.
+        """
+        if isinstance(response, Iterator):
+            return self._create_streaming_response(response)
+        return self._create_json_response(response)

--- a/src/codegate/providers/llamacpp/completion_handler.py
+++ b/src/codegate/providers/llamacpp/completion_handler.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from typing import Any, AsyncIterator, Iterator, Optional, Union
 
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from litellm import ChatCompletionRequest, ModelResponse
 from llama_cpp.llama_types import (
     CreateChatCompletionStreamResponse,
@@ -75,7 +75,7 @@ class LlamaCppCompletionHandler(BaseCompletionHandler):
 
         return convert_to_async_iterator(response) if stream else response
 
-    def create_streaming_response(self, stream: AsyncIterator[Any]) -> StreamingResponse:
+    def _create_streaming_response(self, stream: AsyncIterator[Any]) -> StreamingResponse:
         """
         Create a streaming response from a stream generator. The StreamingResponse
         is the format that FastAPI expects for streaming responses.
@@ -89,3 +89,6 @@ class LlamaCppCompletionHandler(BaseCompletionHandler):
             },
             status_code=200,
         )
+
+    def _create_json_response(self, response: Any) -> JSONResponse:
+        raise NotImplementedError("JSON Reponse in LlamaCPP not implemented yet.")

--- a/src/codegate/providers/llamacpp/provider.py
+++ b/src/codegate/providers/llamacpp/provider.py
@@ -43,4 +43,4 @@ class LlamaCppProvider(BaseProvider):
 
             is_fim_request = self._is_fim_request(request, data)
             stream = await self.complete(data, None, is_fim_request=is_fim_request)
-            return self._completion_handler.create_streaming_response(stream)
+            return self._completion_handler.create_response(stream)

--- a/src/codegate/providers/openai/provider.py
+++ b/src/codegate/providers/openai/provider.py
@@ -49,4 +49,4 @@ class OpenAIProvider(BaseProvider):
 
             is_fim_request = self._is_fim_request(request, data)
             stream = await self.complete(data, api_key, is_fim_request=is_fim_request)
-            return self._completion_handler.create_streaming_response(stream)
+            return self._completion_handler.create_response(stream)

--- a/src/codegate/providers/vllm/provider.py
+++ b/src/codegate/providers/vllm/provider.py
@@ -57,4 +57,4 @@ class VLLMProvider(BaseProvider):
 
             is_fim_request = self._is_fim_request(request, data)
             stream = await self.complete(data, api_key, is_fim_request=is_fim_request)
-            return self._completion_handler.create_streaming_response(stream)
+            return self._completion_handler.create_response(stream)

--- a/tests/providers/litellmshim/test_litellmshim.py
+++ b/tests/providers/litellmshim/test_litellmshim.py
@@ -117,7 +117,7 @@ async def test_create_streaming_response():
     generator = mock_stream_gen()
 
     litellm_shim = LiteLLmShim(stream_generator=sse_stream_generator)
-    response = litellm_shim.create_streaming_response(generator)
+    response = litellm_shim._create_streaming_response(generator)
 
     # Verify response metadata
     assert isinstance(response, StreamingResponse)

--- a/tests/providers/test_registry.py
+++ b/tests/providers/test_registry.py
@@ -43,11 +43,14 @@ class MockCompletionHandler(BaseCompletionHandler):
     ) -> Any:
         pass
 
-    def create_streaming_response(
+    def _create_streaming_response(
         self,
         stream: AsyncIterator[Any],
     ) -> StreamingResponse:
         return StreamingResponse(stream)
+
+    def _create_json_response(self, response: Any) -> Any:
+        raise NotImplementedError
 
 
 class MockInputNormalizer(ModelInputNormalizer):


### PR DESCRIPTION
We are currently not handling non-streaming requests, e.g.
```sh
% curl -SsX POST "http://localhost:8989/vllm/chat/completions" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $token" \
     -d '{
           "model": "Qwen/Qwen2.5-Coder-14B-Instruct",
           "messages": [{"role": "user", "content": "hello."}],
           "stream": false
        }'
```

This PR enables to respons with the entire JSON if the request was non-streaming.

Before PR response:
```
data: 'async for' requires an object with __aiter__ method, got ModelResponse

data: [DONE]
```

After this PR:
```
{
  "id": "chatcmpl-AZyYAAOFMsHdx2rabESYcHjsObIB2",
  "created": 1733137598,
  "model": "gpt-4o-mini-2024-07-18",
  "object": "chat.completion",
  "system_fingerprint": "fp_0705bf87c0",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "Hello! How can I assist you today?",
        "role": "assistant",
        "tool_calls": null,
        "function_call": null
      }
    }
  ],
  "usage": {
    "completion_tokens": 9,
    "prompt_tokens": 9,
    "total_tokens": 18,
    "completion_tokens_details": {
      "accepted_prediction_tokens": 0,
      "audio_tokens": 0,
      "reasoning_tokens": 0,
      "rejected_prediction_tokens": 0
    },
    "prompt_tokens_details": {
      "audio_tokens": 0,
      "cached_tokens": 0
    }
  },
  "service_tier": null
}
```