### PR TITLE
fix: update weaviate EmbeddedOptions import path

### DIFF
--- a/src/codegate/storage/storage_engine.py
+++ b/src/codegate/storage/storage_engine.py
@@ -2,6 +2,7 @@ import structlog
 import weaviate
 from weaviate.classes.config import DataType
 from weaviate.classes.query import MetadataQuery
+from weaviate.embedded import EmbeddedOptions
 
 from codegate.inference.inference_engine import LlamaCppInferenceEngine
 
@@ -24,7 +25,7 @@ class StorageEngine:
     def get_client(self, data_path):
         try:
             client = weaviate.WeaviateClient(
-                embedded_options=weaviate.EmbeddedOptions(persistence_data_path=data_path),
+                embedded_options=EmbeddedOptions(persistence_data_path=data_path),
             )
             return client
         except Exception as e:


### PR DESCRIPTION
Updates the import of EmbeddedOptions in storage_engine.py to use the new recommended path from weaviate.embedded, resolving the Dep010 deprecation warning.