### PR TITLE
Disable tools until we handle them properly

### DIFF
--- a/src/codegate/providers/litellmshim/adapter.py
+++ b/src/codegate/providers/litellmshim/adapter.py
@@ -52,7 +52,13 @@ class LiteLLMAdapterInputNormalizer(ModelInputNormalizer):
         """
         # Make a copy of the data to avoid modifying the original and normalize the message content
         normalized_data = self._normalize_content_messages(data)
-        return self._adapter.translate_completion_input_params(normalized_data)
+        ret = self._adapter.translate_completion_input_params(normalized_data)
+
+        # this is a HACK - either we or liteLLM doesn't handle tools properly
+        # so let's just pretend they doesn't exist
+        if ret.get("tools") is not None:
+            ret["tools"] = []
+        return ret
 
     def denormalize(self, data: ChatCompletionRequest) -> Dict:
         """


### PR DESCRIPTION
Newer versions of continue use tools with Anthropic to perform
modifications. We or litellm (to be investigated) don't handle that well
which means that file modifications don't surface in chat.

Let's just pretend the client didn't ask for tools to be used until we
fix that.
