### PR TITLE
Disable codegate system prompt

### DIFF
--- a/src/codegate/server.py
+++ b/src/codegate/server.py
@@ -40,7 +40,7 @@ def init_app() -> FastAPI:
     steps: List[PipelineStep] = [
         CodegateVersion(),
         CodeSnippetExtractor(),
-        CodegateSystemPrompt(Config.get_config().prompts.codegate_chat),
+        #CodegateSystemPrompt(Config.get_config().prompts.codegate_chat),
         CodegateContextRetriever(Config.get_config().prompts.codegate_chat),
         CodegateSecrets(),
     ]


### PR DESCRIPTION
It was inserting a custom prompt even if there was one already. Pankaj
is working on fixing that, but until we do, let's disable the step to
avoid getting 400s if the client sends a system message.
