### PR TITLE
Use `def` in FastAPI dashboard calls.

### DIFF
--- a/src/codegate/dashboard/dashboard.py
+++ b/src/codegate/dashboard/dashboard.py
@@ -5,9 +5,8 @@ import structlog
 from fastapi import APIRouter
 
 from codegate.dashboard.post_processing import (
-    match_conversations,
     parse_get_alert_conversation,
-    parse_get_prompt_with_output,
+    parse_messages_in_conversations,
 )
 from codegate.dashboard.request_models import AlertConversation, Conversation
 from codegate.db.connection import DbReader
@@ -19,31 +18,19 @@ db_reader = DbReader()
 
 
 @dashboard_router.get("/dashboard/messages")
-async def get_messages() -> List[Conversation]:
+def get_messages() -> List[Conversation]:
     """
     Get all the messages from the database and return them as a list of conversations.
     """
-    prompts_outputs = await db_reader.get_prompts_with_output()
+    prompts_outputs = asyncio.run(db_reader.get_prompts_with_output())
 
-    # Parse the prompts and outputs in parallel
-    async with asyncio.TaskGroup() as tg:
-        tasks = [tg.create_task(parse_get_prompt_with_output(row)) for row in prompts_outputs]
-    partial_conversations = [task.result() for task in tasks]
-
-    conversations = await match_conversations(partial_conversations)
-    return conversations
+    return asyncio.run(parse_messages_in_conversations(prompts_outputs))
 
 
 @dashboard_router.get("/dashboard/alerts")
-async def get_alerts() -> List[AlertConversation]:
+def get_alerts() -> List[AlertConversation]:
     """
     Get all the messages from the database and return them as a list of conversations.
     """
-    alerts_prompt_output = await db_reader.get_alerts_with_prompt_and_output()
-
-    # Parse the prompts and outputs in parallel
-    async with asyncio.TaskGroup() as tg:
-        tasks = [tg.create_task(parse_get_alert_conversation(row)) for row in alerts_prompt_output]
-    alert_conversations = [task.result() for task in tasks if task.result() is not None]
-
-    return alert_conversations
+    alerts_prompt_output = asyncio.run(db_reader.get_alerts_with_prompt_and_output())
+    return asyncio.run(parse_get_alert_conversation(alerts_prompt_output))

--- a/src/codegate/dashboard/request_models.py
+++ b/src/codegate/dashboard/request_models.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -57,7 +57,7 @@ class AlertConversation(BaseModel):
     conversation: Conversation
     alert_id: str
     code_snippet: Optional[CodeSnippet]
-    trigger_string: Optional[str]
+    trigger_string: Optional[Union[str, dict]]
     trigger_type: str
     trigger_category: Optional[str]
     timestamp: datetime.datetime

--- a/src/codegate/pipeline/codegate_context_retriever/codegate.py
+++ b/src/codegate/pipeline/codegate_context_retriever/codegate.py
@@ -88,6 +88,10 @@ class CodegateContextRetriever(PipelineStep):
         # Look for matches in vector DB using list of packages as filter
         searched_objects = await self.get_objects_from_search(last_user_message_str, packages)
 
+        logger.info(
+            f"Found {len(searched_objects)} matches in the database",
+            searched_objects=searched_objects,
+        )
         # If matches are found, add the matched content to context
         if len(searched_objects) > 0:
             # Remove searched objects that are not in packages. This is needed

--- a/src/codegate/pipeline/system_prompt/codegate.py
+++ b/src/codegate/pipeline/system_prompt/codegate.py
@@ -56,6 +56,4 @@ class SystemPrompt(PipelineStep):
             context.add_alert(self.name, trigger_string=prepended_message)
             request_system_message["content"] = prepended_message
 
-        return PipelineResult(
-            request=new_request,
-        )
+        return PipelineResult(request=new_request, context=context)


### PR DESCRIPTION
Quote from [FastAPI docs](https://fastapi.tiangolo.com/async/#path-operation-functions)
> Path operation functions
When you declare a path operation function with normal def instead of async def, it is run in an external threadpool that is then awaited, instead of being called directly (as it would block the server).

What we have experienced in Trusty is that if we use `async def` it will queue the requests and wait for them sequentially (blocking the server). While using just `def` will not block the server as the requests are run in a threadpool. This PR uses `def` in the dashboard functions to not affect User Experience blocking the dashboard.