### PR TITLE
Add word "ecosystem" to the context

### DIFF
--- a/src/codegate/utils/utils.py
+++ b/src/codegate/utils/utils.py
@@ -2,11 +2,11 @@ def generate_vector_string(package) -> str:
     vector_str = f"{package['name']}"
     package_url = ""
     type_map = {
-        "pypi": "Python package available on PyPI",
-        "npm": "JavaScript package available on NPM",
-        "go": "Go package",
-        "crates": "Rust package available on Crates",
-        "java": "Java package",
+        "pypi": "Python package available on PyPI ecosystem",
+        "npm": "JavaScript package available on NPM ecosystem",
+        "go": "Go package ecosystem",
+        "crates": "Rust package available on Crates ecosystem",
+        "java": "Java package available on Maven ecosystem",
     }
     status_messages = {
         "archived": "However, this package is found to be archived and no longer maintained.",


### PR DESCRIPTION
Add the word "ecosystem" to the context. This will help LLM understand the ecosystem of a package and will prevent it from responding with bad Trusty URL such as: https://trustypkg.dev/ecosystem/invokehttp.