### PR TITLE
Add reponse format parameter to LLM chat completion call

### DIFF
--- a/src/codegate/llm_utils/llmclient.py
+++ b/src/codegate/llm_utils/llmclient.py
@@ -121,6 +121,7 @@ class LLMClient:
                 api_key=api_key,
                 temperature=request["temperature"],
                 base_url=base_url,
+                response_format=request["response_format"],
             )
 
             content = response["choices"][0]["message"]["content"]


### PR DESCRIPTION
Setting response format parameter will ensure that the LLM response is JSON.