### PR TITLE
Fix *Optimize this code* when using Stacklok hosted LLM

### DIFF
--- a/src/codegate/pipeline/extract_snippets/output.py
+++ b/src/codegate/pipeline/extract_snippets/output.py
@@ -87,7 +87,7 @@ archived packages: {libobjects_text}\n"
             if line.strip() == "```":
                 # Return content up to and including ```, and the rest
                 before = "\n".join(lines[: i + 1])
-                after = "\n".join(lines[i + 1:])
+                after = "\n".join(lines[i + 1 :])
                 return before, after
         return content, ""
 

--- a/src/codegate/providers/vllm/provider.py
+++ b/src/codegate/providers/vllm/provider.py
@@ -79,5 +79,13 @@ class VLLMProvider(BaseProvider):
             data["base_url"] = config.provider_urls.get("vllm")
 
             is_fim_request = self._is_fim_request(request, data)
+
+            # This is an ugly hack to always force the correct model name if CodeGate is trying
+            # to reach Stacklok hosted models. We need a better way of doing this in the future
+            if is_fim_request and "inference.codegate.ai" in data["base_url"]:
+                data["model"] = "Qwen/Qwen2.5-Coder-14B"
+            else:
+                data["model"] = "Qwen/Qwen2.5-Coder-14B-Instruct"
+
             stream = await self.complete(data, api_key, is_fim_request=is_fim_request)
             return self._completion_handler.create_response(stream)


### PR DESCRIPTION
The call was broken because it was trying to use the wrong model. Force the correct model name depending on the type of request.

Closes: #219, #30