### PR TITLE
feat: add mountpoints for weaviate_data and models_path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,9 @@ ENV CODEGATE_OLLAMA_URL=
 ENV CODEGATE_APP_LOG_LEVEL=WARNING
 ENV CODEGATE_LOG_FORMAT=TEXT
 
+# Define volumes for persistent data
+VOLUME ["/app/weaviate_data", "/app/models"]
+
 # Set the container's default entrypoint
 EXPOSE 8989
 ENTRYPOINT ["/app/scripts/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ docker run -p 8989:8989 -p 8990:80 ghcr.io/stacklok/codegate/codegate:latest
 
 # With persistent data
 docker run -p 8989:8989 -p 8990:80 -v /path/to/volume:/app/weaviate_data ghcr.io/stacklok/codegate/codegate:latest
+
+# With persistent models
+docker run -p 8989:8989 -p 8990:80 -v /path/to/volume:/app/models ghcr.io/stacklok/codegate/codegate:latest
 ```
 
 ### Exposed parameters


### PR DESCRIPTION
This will allow to:
- run image with persistent, pre-created weaviate_data
- run image with previously downloaded models

Closes: #269