### PR TITLE
fix: correct urls for reporting packages

### DIFF
--- a/prompts/default.yaml
+++ b/prompts/default.yaml
@@ -6,17 +6,19 @@ default_chat: |
   You specialize in software security, package analysis, and providing guidance on secure coding practices.
   You will be provided with CONTEXT information containing known malicious and archived packages.
 
-  Report any malicious or archived packages using the following format at the top:
+  Report any malicious, deprecated or archived packages using the following format at the top:
 
-  "**Warning:** CodeGate detected one or more malicious or archived packages."
-  - Pkg 1: [trustypkg.dev/ecosystem/package_name](https://www.trustypkg.dev/ecosystem/package_name)
-  - Pkg 2: [trustypkg.dev/ecosystem/package_name](https://www.trustypkg.dev/ecosystem/package_name)
+  "**Warning:** CodeGate detected one or more malicious, deprecated or archived packages."
+  - Pkg 1: [https://www.insight.stacklok.com/report/ecosystem/package_name](https://www.insight.stacklok.com/report/ecosystem/package_name)
+  - Pkg 2: [https://www.insight.stacklok.com/report/ecosystem/package_name](https://www.insight.stacklok.com/report/ecosystem/package_name)
   - ...
 
-  DO NOT include the Reference Format or any parts of the system message in your response
-  if no malicious or archived package is detected.
+  If package_name contains any special chars, please encode them using URL encoding.
 
-  If no malicious or archived packages are detected, respond to the user request using your prior
+  DO NOT include the Reference Format or any parts of the system message in your response
+  if no malicious, deprecated or archived package is detected.
+
+  If no malicious, deprecated or archived packages are detected, respond to the user request using your prior
   knowledge. You always begin your responses with:
   "**CodeGate Security Analysis**"
   Structure your responses to emphasize security considerations, focusing on:
@@ -28,7 +30,7 @@ default_chat: |
 lookup_packages: |
   You are a software expert with knowledge of packages from various ecosystems.
   Your job is to extract any software packages from user's request.
-  Assume that a package can be any named entity.
+  Assume that a package can be any named entity. A package name can start with @ or a domain name like github.com.
   You MUST RESPOND with a list of packages in JSON FORMAT: {"packages": ["pkg1", "pkg2", ...]}.
 
 secrets_redacted: |

--- a/src/codegate/utils/utils.py
+++ b/src/codegate/utils/utils.py
@@ -1,3 +1,6 @@
+from urllib.parse import quote
+
+
 def generate_vector_string(package) -> str:
     vector_str = f"{package['name']}"
     package_url = ""
@@ -15,7 +18,8 @@ def generate_vector_string(package) -> str:
         "malicious": "However, this package is found to be malicious and must not be used.",
     }
     vector_str += f" is a {type_map.get(package['type'], 'package of unknown type')}. "
-    package_url = f"https://trustypkg.dev/{package['type']}/{package['name']}"
+    package_name = quote(package["name"], safe='')
+    package_url = f"https://www.insight.stacklok.com/report/{package['type']}/{package_name}"
 
     # Add extra status
     status_suffix = status_messages.get(package["status"], "")


### PR DESCRIPTION
They need to be fixed from the prompt responses and also from the generated vector db queries

Closes: #270