### PR TITLE
fix: copy default models to exposed volume on entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,8 +106,16 @@ ENV CODEGATE_OLLAMA_URL=http://host.docker.internal:11434
 ENV CODEGATE_APP_LOG_LEVEL=WARNING
 ENV CODEGATE_LOG_FORMAT=TEXT
 
+# Copy the initial models in the image to default models
+RUN mkdir -p /app/default_models && cp /app/models/* /app/default_models/
+
 # Define volume for persistent data
 VOLUME ["/app/models"]
+
+# give the right permissions
+USER root
+RUN chown -R codegate /app/models
+USER codegate
 
 # Set the container's default entrypoint
 EXPOSE 8989

--- a/README.md
+++ b/README.md
@@ -157,9 +157,6 @@ docker run -p 8989:8989 -p 8990:80 codegate:latest
 docker pull ghcr.io/stacklok/codegate/codegate:latest
 docker run -p 8989:8989 -p 8990:80 ghcr.io/stacklok/codegate/codegate:latest
 
-# With persistent data
-docker run -p 8989:8989 -p 8990:80 -v /path/to/volume:/app/weaviate_data ghcr.io/stacklok/codegate/codegate:latest
-
 # With persistent models
 docker run -p 8989:8989 -p 8990:80 -v /path/to/volume:/app/models ghcr.io/stacklok/codegate/codegate:latest
 ```

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -29,6 +29,8 @@ start_dashboard() {
 
 # Function to start the main application
 start_application() {
+    # first restore the models
+    cp /app/default_models/* /app/models/
     CMD_ARGS="--port 8989 --host 0.0.0.0 --vllm-url $CODEGATE_VLLM_URL --model-base-path $MODEL_BASE_PATH"
 
     # Check and append additional URLs if they are set


### PR DESCRIPTION
When doing that way, user can mount a volume containing the downloaded models, but we also will be copying the embeddings model to that directory, so all needed models are there.