### PR TITLE
fix: use node LTS version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN poetry config virtualenvs.create false && \
 COPY . /app
 
 # Build the webapp
-FROM node:23.4-slim AS webbuilder
+FROM node:22-slim AS webbuilder
 
 # Install curl for downloading the webapp from GH and unzip to extract it
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Node support [LTS](https://nodejs.org/en/about/previous-releases#nodejs-releases) only for even-numbered release version. The odd-numbered release version are considered unsopported after 6 months. 
Replace the node version to a LTS version.