### PR TITLE
start_serving should be False

### DIFF
--- a/src/codegate/providers/copilot/provider.py
+++ b/src/codegate/providers/copilot/provider.py
@@ -388,7 +388,7 @@ class CopilotProvider(asyncio.Protocol):
         """Create and start proxy server"""
         loop = asyncio.get_event_loop()
         server = await loop.create_server(
-            lambda: cls(loop), host, port, ssl=ssl_context, reuse_port=True, start_serving=True
+            lambda: cls(loop), host, port, ssl=ssl_context, reuse_port=True, start_serving=False
         )
         logger.debug(f"Proxy server running on {host}:{port}")
         return server


### PR DESCRIPTION
According to the docs:

start_serving set to True (default) causes the created server to start accepting connections immediately. When set to False, the user should await Server.start_serving() or
Server.serve_forever() to make the server to start accepting connections.

We call `await server.serve_forever()` in `run_proxy_server` so we should allow this command to ditact we are able to accept connections