### PR TITLE
A hotfix for the FIM pipeline

### DIFF
--- a/src/codegate/pipeline/base.py
+++ b/src/codegate/pipeline/base.py
@@ -267,6 +267,7 @@ class InputPipelineInstance:
         self.secret_manager = secret_manager
         self.is_fim = is_fim
         self.context = PipelineContext()
+        self.context.metadata["is_fim"] = is_fim
 
     async def process_request(
         self,


### PR DESCRIPTION
This is not a real fix but a hotfix. The part that is needed and will be
reused later is that we need to select the proper pipeline for
FIM/non-FIM. What makes it a hotfix is that we shortcut for FIM requests
as if we had no pipeline - this is OK for now because our FIM output
pipeline is empty anyway, but we'll have to fix it. For some reason,
piping the FIM output through the output pipeline throws errors.

I'll look into that a bit more, but if we want to get the FIM output
unblocked and without errors, this helps.

Related: #351
