### PR TITLE
Cache FIM entries in memory to avoid repeated writes to DB

### DIFF
--- a/src/codegate/config.py
+++ b/src/codegate/config.py
@@ -52,6 +52,8 @@ class Config:
     server_key: str = "server.key"
     force_certs: bool = False
 
+    max_fim_hash_lifetime: int = 60 * 5  # Time in seconds. Default is 5 minutes.
+
     # Provider URLs with defaults
     provider_urls: Dict[str, str] = field(default_factory=lambda: DEFAULT_PROVIDER_URLS.copy())
 

--- a/src/codegate/pipeline/output.py
+++ b/src/codegate/pipeline/output.py
@@ -112,9 +112,7 @@ class OutputPipelineInstance:
                 self._context.processed_content.append(choice.delta.content)
 
     async def _record_to_db(self):
-        if self._input_context and not self._input_context.metadata.get("stored_in_db", False):
-            await self._db_recorder.record_context(self._input_context)
-            self._input_context.metadata["stored_in_db"] = True
+        await self._db_recorder.record_context(self._input_context)
 
     async def process_stream(
         self, stream: AsyncIterator[ModelResponse]

--- a/src/codegate/providers/base.py
+++ b/src/codegate/providers/base.py
@@ -193,9 +193,7 @@ class BaseProvider(ABC):
         finally:
             if context:
                 # Record to DB the objects captured during the stream
-                if not context.metadata.get("stored_in_db", False):
-                    await self._db_recorder.record_context(context)
-                    context.metadata["stored_in_db"] = True
+                await self._db_recorder.record_context(context)
                 # Ensure sensitive data is cleaned up after the stream is consumed
                 if context.sensitive:
                     context.sensitive.secure_cleanup()

--- a/src/codegate/providers/copilot/provider.py
+++ b/src/codegate/providers/copilot/provider.py
@@ -609,9 +609,7 @@ class CopilotProxyTargetProtocol(asyncio.Protocol):
                             StreamingChoices(
                                 finish_reason=choice.get("finish_reason", None),
                                 index=0,
-                                delta=Delta(
-                                    content=content, role="assistant"
-                                ),
+                                delta=Delta(content=content, role="assistant"),
                                 logprobs=None,
                             )
                         )


### PR DESCRIPTION
Makes a hash dictionary to avoid creating multiple entries for similar FIM requests.

The hashes are either:
- For Copilot: `path_of_file + provider`
- For the rest of providers: `message_received_in_request + provider`

The match for the rest of providers is a bit harder. There are several paths included on the message and the first one is not the path of the "focused" file. I will create an issue to look into them later. For the moment we can do a best effort of hashing the entire content of the request and storing that as a hash.