### PR TITLE
Refine caching non-copilot FIM calls

### DIFF
--- a/tests/db/test_connection.py
+++ b/tests/db/test_connection.py
@@ -1,0 +1,36 @@
+import hashlib
+from unittest.mock import patch
+
+import pytest
+
+from codegate.db.connection import DbRecorder
+
+
+@patch("codegate.db.connection.DbRecorder.__init__", return_value=None)
+def mock_db_recorder(mocked_init) -> DbRecorder:
+    db_recorder = DbRecorder()
+    return db_recorder
+
+
+fim_message = """
+# Path: folder/testing_file.py
+# another_folder/another_file.py
+
+This is a test message
+"""
+
+
+@pytest.mark.parametrize(
+    "message, provider, expected_message_to_hash",
+    [
+        ("This is a test message", "test_provider", "This is a test message-test_provider"),
+        (fim_message, "copilot", "folder/testing_file.py-copilot"),
+        (fim_message, "other", "another_folder/another_file.py-other"),
+    ],
+)
+def test_create_hash_key(message, provider, expected_message_to_hash):
+    mocked_db_recorder = mock_db_recorder()
+    expected_hash = hashlib.sha256(expected_message_to_hash.encode("utf-8")).hexdigest()
+
+    result_hash = mocked_db_recorder._create_hash_key(message, provider)
+    assert result_hash == expected_hash


### PR DESCRIPTION
Closes: #376

We were using the whole content of the prompt to hash the requests that doesn't come from copilot. This is inefficient since the prompt between requests can vary quite a lot. Instead use the filepath included in every request. After some investigation, `copilot` puts the filepath at the top of the prompt while the rest of the providers include the filepath at the bottom of the context section.