### PR TITLE
Add secret type and context lines to secret alert

### DIFF
--- a/src/codegate/providers/copilot/provider.py
+++ b/src/codegate/providers/copilot/provider.py
@@ -9,6 +9,7 @@ import structlog
 from litellm.types.utils import Delta, ModelResponse, StreamingChoices
 
 from codegate.ca.codegate_ca import CertificateAuthority
+from codegate.codegate_logging import setup_logging
 from codegate.config import Config
 from codegate.pipeline.base import PipelineContext
 from codegate.pipeline.factory import PipelineFactory
@@ -21,7 +22,6 @@ from codegate.providers.copilot.pipeline import (
     CopilotPipeline,
 )
 from codegate.providers.copilot.streaming import SSEProcessor
-from src.codegate.codegate_logging import setup_logging
 
 setup_logging()
 logger = structlog.get_logger("codegate").bind(origin="copilot_proxy")


### PR DESCRIPTION
Closes: #365 

Until now we have only stored the redacted secret in the alert string. This PR also stores the type of secret and the surrounding lines in the alert text:
```
"trigger_string": "GitHub - Access Token:\nimport numpy\n\nGITHUB_TOKEN=\"ghp_1J9Z3Z2dfg4dfs23dsfsdf232aadfasdfasfasdf32\"\n\n@app.route(\"/providers\", methods=[\"POST\"])\ndef add_provider():",
```