### PR TITLE
Add custom handler of exceptions

### DIFF
--- a/src/codegate/codegate_logging.py
+++ b/src/codegate/codegate_logging.py
@@ -147,6 +147,7 @@ def setup_logging(
 
     # Set explicitly the log level for other modules
     logging.getLogger("sqlalchemy").setLevel(logging.WARNING)
+    logging.getLogger("uvicorn.error").disabled = True
 
     # Create a logger for our package
     logger = structlog.get_logger("codegate")

--- a/src/codegate/server.py
+++ b/src/codegate/server.py
@@ -1,5 +1,10 @@
+import traceback
+
+import structlog
 from fastapi import APIRouter, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from starlette.middleware.errors import ServerErrorMiddleware
 
 from codegate import __description__, __version__
 from codegate.dashboard.dashboard import dashboard_router
@@ -10,6 +15,16 @@ from codegate.providers.ollama.provider import OllamaProvider
 from codegate.providers.openai.provider import OpenAIProvider
 from codegate.providers.registry import ProviderRegistry
 from codegate.providers.vllm.provider import VLLMProvider
+
+logger = structlog.get_logger("codegate")
+
+async def custom_error_handler(request, exc: Exception):
+    """This is a Middleware to handle exceptions and log them."""
+    # Capture the stack trace
+    extracted_traceback = traceback.extract_tb(exc.__traceback__)
+    # Log only the last 3 items of the stack trace. 3 is an arbitrary number.
+    logger.error(traceback.print_list(extracted_traceback[-3:]))
+    return JSONResponse({"error": str(exc)}, status_code=500)
 
 
 def init_app(pipeline_factory: PipelineFactory) -> FastAPI:
@@ -26,6 +41,8 @@ def init_app(pipeline_factory: PipelineFactory) -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    # Apply error handling middleware
+    app.add_middleware(ServerErrorMiddleware, handler=custom_error_handler)
 
     # Create provider registry
     registry = ProviderRegistry(app)


### PR DESCRIPTION
This will change the way we visualize the Exceptions in FastAPI to a more traditional unformatted approach.
```
  File "/Users/aponcedeleonch/py_venvs/codegate_env/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 2505, in run_sync_in_worker_thread
    return await future
           ^^^^^^^^^^^^
  File "/Users/aponcedeleonch/py_venvs/codegate_env/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 1005, in run
    result = context.run(func, *args)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aponcedeleonch/StacklokRepos/codegate/src/codegate/dashboard/dashboard.py", line 35, in get_messages
    raise Exception("This is a test exception")
2024-12-19T13:45:25.3dZ [error    ] module=server pathname=/Users/aponcedeleonch/StacklokRepos/codegate/src/codegate/server.py
2024-12-19T13:45:25.3dZ [info     ] ::1:59820 - "GET /dashboard/messages HTTP/1.1" 500 module=h11_impl pathname=/Users/aponcedeleonch/py_venvs/codegate_env/lib/python3.12/site-packages/uvicorn/protocols/http/h11_impl.py
```

The advantage would be that we would no longer get really long exceptions from FastAPI