### PR TITLE
Remove the need for secrets at Docker build

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Fetch latest FE commit SHA
         id: fetch_commit_fe_sha
         run: |
-          echo "LATEST_RELEASE=$(curl -s "https://api.github.com/repos/stacklok/codegate-ui/releases/latest" -H "Authorization: Bearer ${{ secrets.GH_CI_TOKEN }}" | grep '"zipball_url":' | cut -d '"' -f 4)" >> $GITHUB_ENV
+          echo "LATEST_RELEASE=$(curl -s "https://api.github.com/repos/stacklok/codegate-ui/releases/latest" | grep '"tag_name":' | cut -d '"' -f 4)" >> $GITHUB_ENV
       - name: Test build on x86
         id: docker_build
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v5
@@ -35,7 +35,5 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          secrets: |
-            gh_token=${{ secrets.GH_CI_TOKEN }}
           build-args: |
             LATEST_RELEASE=${{ env.LATEST_RELEASE }}

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Fetch latest FE commit SHA
         id: fetch_commit_fe_sha
         run: |
-          echo "LATEST_RELEASE=$(curl -s "https://api.github.com/repos/stacklok/codegate-ui/releases/latest" -H "Authorization: Bearer ${{ secrets.GH_CI_TOKEN }}" | grep '"zipball_url":' | cut -d '"' -f 4)" >> $GITHUB_ENV
+          echo "LATEST_RELEASE=$(curl -s "https://api.github.com/repos/stacklok/codegate-ui/releases/latest" | grep '"tag_name":' | cut -d '"' -f 4)" >> $GITHUB_ENV
       - name: Rename to accommodate to image
         run: mv ./backup_weaviate ./weaviate_backup
       - name: Download git lfs dependencies
@@ -84,8 +84,6 @@ jobs:
           labels: ${{ steps.docker-metadata.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          secrets: |
-            gh_token=${{ secrets.GH_CI_TOKEN }}
           build-args: |
             LATEST_RELEASE=${{ env.LATEST_RELEASE }}
       - name: Capture Image Digest

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,10 @@ WORKDIR /usr/src/
 
 # To ensure we always download the latest release of the webapp, we use a build argument.
 # This prevents the curl command from being cached by Docker.
-ARG LATEST_RELEASE=LATEST
+ARG LATEST_RELEASE="v0.0.9"
 RUN echo "Latest FE release: $LATEST_RELEASE"
-RUN --mount=type=secret,id=gh_token \
-    LATEST_RELEASE=${LATEST_RELEASE} \
-    curl -L -H "Authorization: Bearer $(cat /run/secrets/gh_token)" -o main.zip ${LATEST_RELEASE}
+RUN LATEST_RELEASE=${LATEST_RELEASE} \
+    curl -L -o main.zip "https://api.github.com/repos/stacklok/codegate-ui/zipball/${LATEST_RELEASE}"
 
 # Extract the downloaded zip file
 RUN unzip main.zip

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,6 @@ build: clean test
 	poetry build
 
 image-build:
-	DOCKER_BUILDKIT=1 $(CONTAINER_BUILD) -f Dockerfile --secret id=gh_token,env=GH_CI_TOKEN  -t codegate . -t ghcr.io/stacklok/codegate:$(VER) --load
+	DOCKER_BUILDKIT=1 $(CONTAINER_BUILD) -f Dockerfile -t codegate . -t ghcr.io/stacklok/codegate:$(VER) --load
 
 all: clean install format lint test security build


### PR DESCRIPTION
Now that both `codegate` and `codegate-ui` repos are public we don't have a need for passing a secret at build time. This also facilitates building docker images locally.