### PR TITLE
Fix Deprecation Warnings

### DIFF
--- a/src/codegate/ca/codegate_ca.py
+++ b/src/codegate/ca/codegate_ca.py
@@ -173,7 +173,7 @@ class CertificateAuthority:
                         self._cert_cache[common_name] = CachedCertificate(
                             cert_path=cert_path,
                             key_path=key_path,
-                            creation_time=datetime.utcnow(),
+                            creation_time=datetime.now(datetime.UTC),
                         )
                     else:
                         logger.debug(f"Skipping expired certificate for {common_name}")

--- a/src/codegate/pipeline/codegate_context_retriever/codegate.py
+++ b/src/codegate/pipeline/codegate_context_retriever/codegate.py
@@ -68,9 +68,7 @@ class CodegateContextRetriever(PipelineStep):
 
         # Vector search to find bad packages
         storage_engine = StorageEngine()
-        searched_objects = await storage_engine.search(
-            query=user_messages, distance=0.8, limit=100
-        )
+        searched_objects = await storage_engine.search(query=user_messages, distance=0.8, limit=100)
 
         logger.info(
             f"Found {len(searched_objects)} matches in the database",

--- a/src/codegate/utils/package_extractor.py
+++ b/src/codegate/utils/package_extractor.py
@@ -69,7 +69,7 @@ class PackageExtractor:
                         (use_wildcard) @import_name)
                     (use_declaration
                         (use_as_clause (scoped_identifier) @import_name))
-                """
+                """,
     }
 
     @staticmethod

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from click.testing import CliRunner
 from fastapi.middleware.cors import CORSMiddleware
@@ -143,7 +144,7 @@ def test_system_routes(mock_pipeline_factory) -> None:
 async def test_async_health_check(mock_pipeline_factory) -> None:
     """Test the health check endpoint with async client."""
     app = init_app(mock_pipeline_factory)
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    async with AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as ac:
         response = await ac.get("/health")
         assert response.status_code == 200
         assert response.json() == {"status": "healthy"}


### PR DESCRIPTION
Fix for the following warnings:

- The 'app' shortcut is now deprecated.
- datetime.datetime.utcnow() is deprecated

Closes: #366