### PR TITLE
Fix CI by removing the need for a secret

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Fetch latest FE commit SHA
         id: fetch_commit_fe_sha
         run: |
-          echo "LATEST_RELEASE=$(curl -s "https://api.github.com/repos/stacklok/codegate-ui/releases/latest" -H "Authorization: Bearer ${{ secrets.GH_CI_TOKEN }}" | grep '"zipball_url":' | cut -d '"' -f 4)" >> $GITHUB_ENV
+          echo "LATEST_RELEASE=$(curl -s "https://api.github.com/repos/stacklok/codegate-ui/releases/latest" | grep '"zipball_url":' | cut -d '"' -f 4)" >> $GITHUB_ENV
       - name: Test build on x86
         id: docker_build
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,10 @@ WORKDIR /usr/src/
 
 # To ensure we always download the latest release of the webapp, we use a build argument.
 # This prevents the curl command from being cached by Docker.
+
 ARG LATEST_RELEASE=LATEST
 RUN echo "Latest FE release: $LATEST_RELEASE"
-RUN --mount=type=secret,id=gh_token \
-    LATEST_RELEASE=${LATEST_RELEASE} \
-    curl -L -H "Authorization: Bearer $(cat /run/secrets/gh_token)" -o main.zip ${LATEST_RELEASE}
+RUN LATEST_RELEASE=${LATEST_RELEASE} curl -L  -o main.zip ${LATEST_RELEASE}
 
 # Extract the downloaded zip file
 RUN unzip main.zip


### PR DESCRIPTION
Now that codegate-ui is public, there should be no need for a secret