### PR TITLE
fix: remove Authorization header from img publish

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Fetch latest FE commit SHA
         id: fetch_commit_fe_sha
         run: |
-          echo "LATEST_RELEASE=$(curl -s "https://api.github.com/repos/stacklok/codegate-ui/releases/latest" -H "Authorization: Bearer ${{ secrets.GH_CI_TOKEN }}" | grep '"zipball_url":' | cut -d '"' -f 4)" >> $GITHUB_ENV
+          echo "LATEST_RELEASE=$(curl -s "https://api.github.com/repos/stacklok/codegate-ui/releases/latest" | grep '"zipball_url":' | cut -d '"' -f 4)" >> $GITHUB_ENV
       - name: Download git lfs dependencies
         run: |
           git lfs install


### PR DESCRIPTION
Since the repos are public we don't need the `Authorization` header anymore.