### PR TITLE
Fix release download

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -20,10 +20,10 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3
-      - name: Fetch latest FE commit SHA
-        id: fetch_commit_fe_sha
+      - name: Fetch latest release URL
+        id: fetch_release_url
         run: |
-          echo "LATEST_RELEASE=$(curl -s "https://api.github.com/repos/stacklok/codegate-ui/releases/latest" | grep '"zipball_url":' | cut -d '"' -f 4)" >> $GITHUB_ENV
+          echo "LATEST_RELEASE=$(curl -s "https://api.github.com/repos/stacklok/codegate-ui/releases/latest" | jq -r '.zipball_url')" >> $GITHUB_ENV
       - name: Test build on x86
         id: docker_build
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /usr/src/
 
-# Set the release URL (this should be static and not change often) and download latest 
-RUN curl -s https://api.github.com/repos/stacklok/codegate-ui/releases/latest | jq -r '.zipball_url' | xargs curl -L -o main.zip
+# Set build arg for latest release URL (optional)
+ARG LATEST_RELEASE
+
+# Download the latest release - if LATEST_RELEASE is provided use it, otherwise fetch from API
+RUN if [ -n "$LATEST_RELEASE" ]; then \
+        echo "Using provided release URL" && \
+        curl -L -o main.zip "${LATEST_RELEASE}"; \
+    else \
+        echo "Fetching latest release URL" && \
+        curl -s https://api.github.com/repos/stacklok/codegate-ui/releases/latest | \
+        jq -r '.zipball_url' | xargs curl -L -o main.zip; \
+    fi
 
 # Extract the downloaded zip file
 RUN unzip main.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /usr/src/
 
 # Set the release URL (this should be static and not change often) and download latest 
-ARG LATEST_RELEASE="https://api.github.com/repos/stacklok/codegate-ui/releases/latest"
-RUN curl -s ${LATEST_RELEASE} | jq -r '.zipball_url' | xargs curl -L -o main.zip
+RUN curl -s https://api.github.com/repos/stacklok/codegate-ui/releases/latest | jq -r '.zipball_url' | xargs curl -L -o main.zip
 
 # Extract the downloaded zip file
 RUN unzip main.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,22 +24,20 @@ COPY . /app
 # Build the webapp
 FROM node:23-slim AS webbuilder
 
+
+
 # Install curl for downloading the webapp from GH and unzip to extract it
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     jq \
-    unzip \
+    unzip\
     ca-certificates
 
 WORKDIR /usr/src/
 
-# Ensure the LATEST_RELEASE argument is passed or set a default value
+# Set the release URL (this should be static and not change often) and download latest 
 ARG LATEST_RELEASE="https://api.github.com/repos/stacklok/codegate-ui/releases/latest"
-RUN echo "Latest FE release: $LATEST_RELEASE" \
-    && TAG=$(curl -s $LATEST_RELEASE | jq -r '.tag_name') \
-    && echo "Latest FE release: ${TAG}" \
-    && ZIP_URL=$(curl -s $LATEST_RELEASE | jq -r '.zipball_url') \
-    && curl -L -o main.zip $ZIP_URL
+RUN curl -s ${LATEST_RELEASE} | jq -r '.zipball_url' | xargs curl -L -o main.zip
 
 # Extract the downloaded zip file
 RUN unzip main.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,14 +31,15 @@ ARG LATEST_RELEASE=https://api.github.com/repos/stacklok/codegate-ui/releases/la
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     jq \
-    unzip\
+    unzip \
     ca-certificates
 
 WORKDIR /usr/src/
 
-# Download the latest release of the webapp
-RUN echo "Latest FE release: $(curl -s ${LATEST_RELEASE} | jq -r '.tag_name')"
-RUN curl -s ${LATEST_RELEASE} | jq -r '.zipball_url' | xargs curl -L -o main.zip
+# Download the latest release of the webapp in one single RUN instruction
+RUN TAG=$(curl -s ${LATEST_RELEASE} | jq -r '.tag_name') && \
+    echo "Latest FE release: ${TAG}" && \
+    curl -s ${LATEST_RELEASE} | jq -r '.zipball_url' | xargs curl -L -o main.zip
 
 # Extract the downloaded zip file
 RUN unzip main.zip


### PR DESCRIPTION
Tested as below:

```
=> [webbuilder  5/11] RUN curl -s https://api.github.com/repos/stacklok/codegate-ui/releases/latest | jq -r '.zipball_url' | xargs curl -L -o main.zip     1.0s
 => CACHED [builder 2/7] RUN apt-get update && apt-get install -y --no-install-recommends     gcc     g++     && rm -rf /var/lib/apt/lists/*                0.0s
 => CACHED [builder 3/7] RUN pip install poetry==1.8.4 && rm -rf /root/.cache/pip                                                                           0.0s
 => CACHED [builder 4/7] WORKDIR /app                                                                                                                       0.0s
 => CACHED [builder 5/7] COPY pyproject.toml poetry.lock* /app/                                                                                             0.0s
 => CACHED [builder 6/7] RUN poetry config virtualenvs.create false &&     poetry install --no-dev                                                          0.0s
 => [builder 7/7] COPY . /app                                                                                                                               3.3s
 => [webbuilder  6/11] RUN unzip main.zip                                                                                                                   0.4s
 => [webbuilder  7/11] RUN rm main.zip                                                                                                                      0.2s 
 => [webbuilder  8/11] RUN mv *codegate-ui* webapp                                                                                                          0.4s 
 => [webbuilder  9/11] WORKDIR /usr/src/webapp                                                                                                              0.0s 
 => [webbuilder 10/11] RUN npm install                                                                                                                      5.8s 
 => CACHED [runtime  2/12] RUN apt-get update && apt-get install -y --no-install-recommends     libgomp1     nginx     && rm -rf /var/lib/apt/lists/*       0.0s 
 => CACHED [runtime  3/12] RUN useradd -m -u 1000 -r codegate                                                                                               0.0s 
 => CACHED [runtime  4/12] RUN chown -R codegate /var/lib/nginx &&     chown -R codegate /var/log/nginx &&     chown -R codegate /run                       0.0s
 => CACHED [runtime  5/12] COPY nginx.conf /etc/nginx/conf.d/default.conf                                                                                   0.0s
 => CACHED [runtime  6/12] WORKDIR /app                                                                                                                     0.0s
 => CACHED [runtime  7/12] COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages                              0.0s
 => [runtime  8/12] COPY --from=builder /app /app                                                                                                           1.9s
 => [webbuilder 11/11] RUN npm run build                                                                                                                    6.8s
 => [runtime  9/12] COPY --from=webbuilder /usr/src/webapp/dist /var/www/html                                                                               0.0s
 => [runtime 10/12] RUN mkdir -p /app/default_models && cp /app/codegate_volume/models/* /app/default_models/                                               0.2s
 => [runtime 11/12] RUN mkdir -p /app/codegate_volume/db                                                                                                    0.1s
 => [runtime 12/12] RUN chown -R codegate /app/codegate_volume                                                                                              0.3s
 => exporting to image                                                                                                                                      1.2s
 => => exporting layers                                                                                                                                     1.2s
 => => writing image sha256:90c843e4390c8f0aa96fd7652f2cb19fe9f8dea6194597c0d9904501349852b4                                                                0.0s
 => => naming to docker.io/stacklok/codegate-cg                         
```