### PR TITLE
fix: incorrect datetime format for strftime() in windows

### DIFF
--- a/src/codegate/codegate_logging.py
+++ b/src/codegate/codegate_logging.py
@@ -82,7 +82,7 @@ def setup_logging(
     # Adds log level and timestamp to log entries
     shared_processors = [
         structlog.processors.add_log_level,
-        structlog.processors.TimeStamper(fmt="%Y-%m-%dT%H:%M:%S.%03dZ", utc=True),
+        structlog.processors.TimeStamper(fmt="%Y-%m-%dT%H:%M:%S.%fZ", utc=True),
         add_origin,
         structlog.processors.CallsiteParameterAdder(
             [


### PR DESCRIPTION
The datetime format used with Structlog's configuration inside `setup_logging()` in `src/codegate/codegate_logging.py` is passed to `strftime()`, which works on Linux but returns an error on Windows. Changed the datetime format so it works on Linux as well as Windows.

Resolves #556