### PR TITLE
fix: Add back support for matching AWS SECRET ACCESS KEY

### DIFF
--- a/signatures.yaml
+++ b/signatures.yaml
@@ -1,7 +1,7 @@
 ---
 - Amazon:
     - Access Key: (?:A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA|ABIA|ACCA)[A-Z0-9]{16}
-    # - Secret Access Key: (?<![A-Za-z0-9\/+])[A-Za-z0-9\/+=]{40}(?![A-Za-z0-9\/+=])
+    - Secret Access Key: (?<![A-Za-z0-9/+])[A-Za-z0-9+=][A-Za-z0-9/+=]{38}[A-Za-z0-9+=](?![A-Za-z0-9/+=])
     # - Cognito User Pool ID: (?i)us-[a-z]{2,}-[a-z]{4,}-\d{1,}
     - RDS Password: (?i)(rds\-master\-password|db\-password)
     - SNS Confirmation URL: (?i)https:\/\/sns\.[a-z0-9-]+\.amazonaws\.com\/?Action=ConfirmSubscription&Token=[a-zA-Z0-9-=_]+


### PR DESCRIPTION
Tested with
```
wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY <--- Matched
/home/sdfsdfsdFasssfsdfsdf/sdfsdfsdfsdf/ <--- Not
/home/sdfsdfsdFsssdfsdfsdf/sdfsdfsdfsdfa <--- Not
home/sdfsdfsdfsssdfsdfsdf/sdfsdfsdfsdfa/ <--- Not
```