### PR TITLE
Add build-arg in `make image-build` command

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -35,7 +35,5 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          secrets: |
-            gh_token=${{ secrets.GH_CI_TOKEN }}
           build-args: |
             LATEST_RELEASE=${{ env.LATEST_RELEASE }}

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -85,8 +85,6 @@ jobs:
           labels: ${{ steps.docker-metadata.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          secrets: |
-            gh_token=${{ secrets.GH_CI_TOKEN }}
           build-args: |
             LATEST_RELEASE=${{ env.LATEST_RELEASE }}
       - name: Capture Image Digest

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: clean install format lint test security build all
 CONTAINER_BUILD?=docker buildx build
-VER?=0.1.0
+VER?=0.1.7
 
 clean:
 	rm -rf build/
@@ -30,6 +30,12 @@ build: clean test
 	poetry build
 
 image-build:
-	DOCKER_BUILDKIT=1 $(CONTAINER_BUILD) -f Dockerfile --secret id=gh_token,env=GH_CI_TOKEN  -t codegate . -t ghcr.io/stacklok/codegate:$(VER) --load
+	DOCKER_BUILDKIT=1 $(CONTAINER_BUILD) \
+		-f Dockerfile \
+		--build-arg LATEST_RELEASE=$(curl -s "https://api.github.com/repos/stacklok/codegate-ui/releases/latest" | grep '"zipball_url":' | cut -d '"' -f 4) \
+		-t codegate \
+		. \
+		-t ghcr.io/stacklok/codegate:$(VER) \
+		--load
 
 all: clean install format lint test security build


### PR DESCRIPTION
The build-arg prevents that the step for downloading the UI code is cached. This way we can ensure that we are always using the latest releasee from the UI when building the image locally. The build-arg is already present in the GH action to build and publish the image.

Additionally, remove the `secret` provided to the GH action to build the image. It was used when the containers were not public