### PR TITLE
Add all-in-one minimal nginx config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN chown -R codegate /var/lib/nginx && \
     chown -R codegate /var/log/nginx && \
     chown -R codegate /run
 
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/nginx.conf
 
 # Remove include /etc/nginx/sites-enabled/*; from the default nginx.conf
 # This way we don't introduce unnecessary configurations nor serve

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,22 +1,68 @@
-server {
-  listen 9090;
+worker_processes 1;
+pid /run/nginx.pid;
+error_log /var/log/nginx/error.log;
+include /etc/nginx/modules-enabled/*.conf;
 
-  server_name localhost;
+events {
+	worker_connections 128;
+}
 
-  root /var/www/html;
-  index index.html;
+http {
 
-  location / {
-    try_files $uri /index.html =404;
-  }
+	##
+	# Basic Settings
+	##
 
-  # Serve certificates from /app/codegate_volume/certs at /certificates
-  location /certificates/codegate_ca.crt {
-      alias /app/codegate_volume/certs/ca.crt;
-      types { application/x-x509-ca-cert crt; }
-      default_type application/x-x509-ca-cert;
-  }
+	sendfile on;
+	tcp_nopush on;
+	types_hash_max_size 2048;
 
-  error_log /var/log/nginx/error.log;
-  access_log /var/log/nginx/access.log;
+	##
+	# Disable unnecessary features
+	##
+
+	server_tokens off;
+	autoindex off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# Logging Settings
+	##
+
+	access_log off;
+	error_log /var/log/nginx/error.log;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+
+	server {
+		listen 9090;
+
+		server_name localhost;
+
+		add_header X-Frame-Options SAMEORIGIN;
+		add_header X-Content-Type-Options nosniff;
+		add_header X-XSS-Protection "1; mode=block";
+
+		root /var/www/html;
+		index index.html;
+
+		location / {
+			try_files $uri /index.html =404;
+			expires 1h; # Cache files for 1 hour
+			add_header Cache-Control "public, max-age=3600";
+		}
+
+		# Serve certificates from /app/codegate_volume/certs at /certificates
+		location /certificates/codegate_ca.crt {
+			alias /app/codegate_volume/certs/ca.crt;
+			types { application/x-x509-ca-cert crt; }
+			default_type application/x-x509-ca-cert;
+		}
+	}
 }


### PR DESCRIPTION
The nginx configuration uses a lot of defaults that work well in
server-like environments. However, this is not optimized for a local
dev-environment or single-container as codegate is meant to run.

The nginx server spawns several processes which mostly remain idle. This
is wasteful and it is taking over resources that could be used for
something else. The intention of this new configuration is to minimize
footprint.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
