### PR TITLE
Use `latest` tag to build local codegate container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: clean install format lint test security build all
 CONTAINER_BUILD?=docker buildx build
-VER?=0.1.7
+# This is the container tag. Only used for development purposes.
+VER?=latest
 
 clean:
 	rm -rf build/


### PR DESCRIPTION
There is no use in keeping this variable as it's only used for the
container tag. Releases use another tagging mechanism.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
