### PR TITLE
Get version dynamically as opposed to the hardcoded one we have now

### DIFF
--- a/src/codegate/__init__.py
+++ b/src/codegate/__init__.py
@@ -14,9 +14,6 @@ except metadata.PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"
     __description__ = "codegate"
 
-__version__ = "0.1.7"
-__description__ = "A configurable service gateway"
-
 __all__ = ["Config", "ConfigurationError", "LogFormat", "LogLevel", "setup_logging"]
 
 # Set up null handler to avoid "No handler found" warnings.


### PR DESCRIPTION
This leverages the package metadata instead of overwriting it with a
hardcoded version and description.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
