### PR TITLE
fix: correct problems with ollama and aider

### DIFF
--- a/src/codegate/providers/ollama/provider.py
+++ b/src/codegate/providers/ollama/provider.py
@@ -58,6 +58,9 @@ class OllamaProvider(BaseProvider):
             https://github.com/ollama/ollama/blob/main/docs/api.md#show-model-information
             """
             body = await request.body()
+            body_json = json.loads(body)
+            if "name" not in body_json:
+                raise HTTPException(status_code=400, detail="model is required in the request body")
             async with httpx.AsyncClient() as client:
                 response = await client.post(
                     f"{self.base_url}/api/show",


### PR DESCRIPTION
It has a pair of problems:
- always need to check that the model contains some value
- only send chunks that contain data, and do not send double newlines as they get considered as a different chunk

Closes: #586