### PR TITLE
If the LLM uses ellipsis in place of the REDACTED string, print the original version

### DIFF
--- a/src/codegate/pipeline/secrets/secrets.py
+++ b/src/codegate/pipeline/secrets/secrets.py
@@ -312,8 +312,8 @@ class SecretUnredactionStep(OutputPipelineStep):
     """Pipeline step that unredacts protected content in the stream"""
 
     def __init__(self):
-        self.redacted_pattern = re.compile(r"REDACTED<\$([^>]+)>")
-        self.marker_start = "REDACTED<$"
+        self.redacted_pattern = re.compile(r"REDACTED<(\$?[^>]+)>")
+        self.marker_start = "REDACTED<"
         self.marker_end = ">"
 
     @property
@@ -365,6 +365,10 @@ class SecretUnredactionStep(OutputPipelineStep):
         if match:
             # Found a complete marker, process it
             encrypted_value = match.group(1)
+            # Strip the $ if it exists before trying to decrypt
+            if encrypted_value.startswith('$'):
+                encrypted_value = encrypted_value[1:]
+
             original_value = input_context.sensitive.manager.get_original_value(
                 encrypted_value,
                 input_context.sensitive.session_id,


### PR DESCRIPTION
I was able to make the LLM to reply with `REDACTED=<...>` when
summarizing code. Because our regex and the prefix marker expected the
redacted string to contain the dollar sign, we never flushed the prefix
buffer correctly and ended up later flushing repeatedly.
