### PR TITLE
Set codegate version from build argument in container

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -87,6 +87,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             LATEST_RELEASE=${{ env.LATEST_RELEASE }}
+            CODEGATE_VERSION=${{ steps.version-string.outputs.tag }}
       - name: Capture Image Digest
         id: image-digest
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Builder stage: Install dependencies and build the application
 FROM python:3.12-slim AS builder
 
+ARG CODEGATE_VERSION=dev
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
@@ -20,6 +22,9 @@ RUN poetry config virtualenvs.create false && \
 
 # Copy the rest of the application
 COPY . /app
+
+# Overwrite the _VERSION variable in the code
+RUN sed -i "s/_VERSION =.*/_VERSION = \"${CODEGATE_VERSION}\"/g" /app/src/codegate/__init__.py
 
 # Build the webapp
 FROM node:23-slim AS webbuilder

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ image-build:
 	DOCKER_BUILDKIT=1 $(CONTAINER_BUILD) \
 		-f Dockerfile \
 		--build-arg LATEST_RELEASE=$(curl -s "https://api.github.com/repos/stacklok/codegate-ui/releases/latest" | grep '"zipball_url":' | cut -d '"' -f 4) \
+		--build-arg CODEGATE_VERSION="$(shell git describe --tags --abbrev=0)-$(shell git rev-parse --short HEAD)-dev" \
 		-t codegate \
 		. \
 		-t ghcr.io/stacklok/codegate:$(VER) \

--- a/src/codegate/__init__.py
+++ b/src/codegate/__init__.py
@@ -7,12 +7,19 @@ from codegate.codegate_logging import LogFormat, LogLevel, setup_logging
 from codegate.config import Config
 from codegate.exceptions import ConfigurationError
 
-try:
-    __version__ = metadata.version("codegate")
-    __description__ = metadata.metadata("codegate")["Summary"]
-except metadata.PackageNotFoundError:  # pragma: no cover
-    __version__ = "unknown"
-    __description__ = "codegate"
+_VERSION = "dev"
+_DESC = "CodeGate - A Generative AI security gateway."
+
+def __get_version_and_description() -> tuple[str, str]:
+    try:
+        version = metadata.version("codegate")
+        description = metadata.metadata("codegate")["Summary"]
+    except metadata.PackageNotFoundError:
+        version = _VERSION
+        description = _DESC
+    return version, description
+
+__version__, __description__ = __get_version_and_description()
 
 __all__ = ["Config", "ConfigurationError", "LogFormat", "LogLevel", "setup_logging"]
 


### PR DESCRIPTION
The codegate container does not run the python program via poetry, thus
it does not have the necessary package metadata to determine the
version.

To work around this lack of information, this enhancement leverages
Docker build arguments to set a special variable that will set the
version. This way, we don't need to rely on package metadata nor
manually bump the version. This machinery was set up in both the local
image building and in CI, so we'll get the version and a commit hash.

Sample output looks as follows:

![image](https://github.com/user-attachments/assets/b5bb9905-1db1-413e-a32e-627b3f028586)

