### PR TITLE
Require codegate version when issuing a bug.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -45,7 +45,7 @@ body:
     attributes:
       label: "IDE and Version"
       description: "Enter the IDE name and version."
-      placeholder: "e.g., VS Code 1.78.0"
+      placeholder: "e.g. VS Code 1.78.0"
     validations:
       required: true
 
@@ -54,7 +54,7 @@ body:
     attributes:
       label: "Extension and Version"
       description: "Enter the extension name and version."
-      placeholder: "e.g., Proxy Extension 0.5.1"
+      placeholder: "e.g. Proxy Extension 0.5.1"
     validations:
       required: true
 
@@ -77,8 +77,17 @@ body:
     id: model
     attributes:
       label: "Model"
-      description: "Enter the model name used (e.g., GPT-4, Claude 3)."
-      placeholder: "e.g., GPT-4"
+      description: "Enter the model name used (e.g. GPT-4, Claude 3)."
+      placeholder: "e.g. GPT-4"
+    validations:
+      required: true
+
+  - type: input
+    id: codegate-version
+    attributes:
+      label: "Codegate version"
+      description: "Enter the version of CodeGate (e.g. `v0.1.8`, `4845e00c039e`)."
+      placeholder: "e.g. v0.1.8"
     validations:
       required: true
 


### PR DESCRIPTION
I don't think codegate version is explicitly requested in any of the other fields, so I added a new one.