### PR TITLE
Revert "Add bandit to the CI pipeline"

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,22 +28,3 @@ jobs:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-
-  bandit:
-    runs-on: ubuntu-latest
-    name: Bandit
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-      - name: Set up Python
-        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install bandit
-
-      - name: Run bandit
-        run: |
-          bandit -r ./src/codegate


### PR DESCRIPTION
Reverts stacklok/codegate#619

This is already done via `make security`.

References:
* https://github.com/stacklok/codegate/blob/147205abaa9c5572e2cae62ffabcac073292e791/Makefile#L28
* https://github.com/stacklok/codegate/blob/147205abaa9c5572e2cae62ffabcac073292e791/.github/workflows/ci.yml#L57