### PR TITLE
Don't include provider routes in OpenAPI schema

### DIFF
--- a/src/codegate/providers/registry.py
+++ b/src/codegate/providers/registry.py
@@ -16,7 +16,7 @@ class ProviderRegistry:
         to the FastAPI app.
         """
         self.providers[name] = provider
-        self.app.include_router(provider.get_routes())
+        self.app.include_router(provider.get_routes(), include_in_schema=False)
 
     def get_provider(self, name: str) -> Optional[BaseProvider]:
         """


### PR DESCRIPTION
For all providers, this ensures that their routes are not included in
FastAPI's auto-generated OpenAPI schema.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
