### PR TITLE
fix: do not assume streaming for ollama

### DIFF
--- a/src/codegate/providers/ollama/adapter.py
+++ b/src/codegate/providers/ollama/adapter.py
@@ -25,10 +25,8 @@ class OllamaInputNormalizer(ModelInputNormalizer):
                 {"content": normalized_data.pop("prompt"), "role": "user"}
             ]
 
-        # In Ollama force the stream to be True. Continue is not setting this parameter and
-        # most of our functionality is for streaming completions.
-        normalized_data["stream"] = True
-
+        # if we have the stream flag in data we set it, otherwise defaults to true
+        normalized_data["stream"] = data.get("stream", True)
         return ChatCompletionRequest(**normalized_data)
 
     def denormalize(self, data: ChatCompletionRequest) -> Dict:

--- a/src/codegate/providers/ollama/completion_handler.py
+++ b/src/codegate/providers/ollama/completion_handler.py
@@ -60,7 +60,7 @@ class OllamaShim(BaseCompletionHandler):
         """
         return StreamingResponse(
             ollama_stream_generator(stream),
-            media_type="application/x-ndjson",
+            media_type="application/x-ndjson; charset=utf-8",
             headers={
                 "Cache-Control": "no-cache",
                 "Connection": "keep-alive",
@@ -70,4 +70,4 @@ class OllamaShim(BaseCompletionHandler):
     def _create_json_response(
         self, response: Union[GenerateResponse, ChatResponse]
     ) -> JSONResponse:
-        return JSONResponse(content=response.model_dump_json(), status_code=200)
+        return JSONResponse(status_code=200, content=response.model_dump())

--- a/src/codegate/providers/ollama/provider.py
+++ b/src/codegate/providers/ollama/provider.py
@@ -65,7 +65,7 @@ class OllamaProvider(BaseProvider):
                 response = await client.post(
                     f"{self.base_url}/api/show",
                     content=body,
-                    headers={"Content-Type": "application/json"},
+                    headers={"Content-Type": "application/json; charset=utf-8"},
                 )
                 return response.json()
 


### PR DESCRIPTION
Aider is sending a mix of requests that need stream or sync processing and we were hardcoding stream to True. Instead, pick if from the request and also fix the formatting of the json response

Closes: #624