### PR TITLE
Use exceptions for handling workspace add error

### DIFF
--- a/src/codegate/dashboard/dashboard.py
+++ b/src/codegate/dashboard/dashboard.py
@@ -6,8 +6,8 @@ import requests
 import structlog
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.responses import StreamingResponse
-from codegate import __version__
 
+from codegate import __version__
 from codegate.dashboard.post_processing import (
     parse_get_alert_conversation,
     parse_messages_in_conversations,
@@ -82,7 +82,7 @@ def version_check():
         latest_version_stripped = latest_version.lstrip('v')
 
         is_latest: bool = latest_version_stripped == current_version
-        
+
         return {
             "current_version": current_version,
             "latest_version": latest_version_stripped,

--- a/src/codegate/workspaces/crud.py
+++ b/src/codegate/workspaces/crud.py
@@ -1,16 +1,19 @@
 import datetime
-from typing import Optional, Tuple, List
+from typing import List, Optional, Tuple
 
 from codegate.db.connection import DbReader, DbRecorder
-from codegate.db.models import Session, Workspace, WorkspaceActive, ActiveWorkspace
+from codegate.db.models import ActiveWorkspace, Session, Workspace, WorkspaceActive
 
+
+class WorkspaceCrudError(Exception):
+    pass
 
 class WorkspaceCrud:
 
     def __init__(self):
         self._db_reader = DbReader()
 
-    async def add_workspace(self, new_workspace_name: str) -> bool:
+    async def add_workspace(self, new_workspace_name: str) -> Workspace:
         """
         Add a workspace
 
@@ -19,7 +22,7 @@ class WorkspaceCrud:
         """
         db_recorder = DbRecorder()
         workspace_created = await db_recorder.add_workspace(new_workspace_name)
-        return bool(workspace_created)
+        return workspace_created
 
     async def get_workspaces(self)-> List[WorkspaceActive]:
         """


### PR DESCRIPTION
This stops using the boolean and instead will raise exceptions if
there's an issue adding a workspace. This will help us differentiate if
the operation failed due to a name already being taken, or the name
having invalid characters.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
