### PR TITLE
feat: Let the user add their own system prompts

### DIFF
--- a/migrations/versions/a692c8b52308_add_workspace_system_prompt.py
+++ b/migrations/versions/a692c8b52308_add_workspace_system_prompt.py
@@ -1,0 +1,27 @@
+"""add_workspace_system_prompt
+
+Revision ID: a692c8b52308
+Revises: 5c2f3eee5f90
+Create Date: 2025-01-17 16:33:58.464223
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a692c8b52308'
+down_revision: Union[str, None] = '5c2f3eee5f90'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add column to workspaces table
+    op.execute("ALTER TABLE workspaces ADD COLUMN system_prompt TEXT DEFAULT NULL;")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE workspaces DROP COLUMN system_prompt;")

--- a/migrations/versions/a692c8b52308_add_workspace_system_prompt.py
+++ b/migrations/versions/a692c8b52308_add_workspace_system_prompt.py
@@ -5,15 +5,14 @@ Revises: 5c2f3eee5f90
 Create Date: 2025-01-17 16:33:58.464223
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
-import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
-revision: str = 'a692c8b52308'
-down_revision: Union[str, None] = '5c2f3eee5f90'
+revision: str = "a692c8b52308"
+down_revision: Union[str, None] = "5c2f3eee5f90"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -275,6 +275,20 @@ class DbRecorder(DbCodeGate):
             raise AlreadyExistsError(f"Workspace {workspace_name} already exists.")
         return added_workspace
 
+    async def update_workspace(self, workspace: Workspace) -> Optional[Workspace]:
+        sql = text(
+            """
+            UPDATE workspaces SET
+            name = :name,
+            system_prompt = :system_prompt
+            WHERE id = :id
+            RETURNING *
+            """
+        )
+        # We only pass an object to respect the signature of the function
+        updated_workspace = await self._execute_update_pydantic_model(workspace, sql)
+        return updated_workspace
+
     async def update_session(self, session: Session) -> Optional[Session]:
         sql = text(
             """
@@ -392,11 +406,11 @@ class DbReader(DbCodeGate):
         workspaces = await self._execute_select_pydantic_model(WorkspaceActive, sql)
         return workspaces
 
-    async def get_workspace_by_name(self, name: str) -> List[Workspace]:
+    async def get_workspace_by_name(self, name: str) -> Optional[Workspace]:
         sql = text(
             """
             SELECT
-                id, name
+                id, name, system_prompt
             FROM workspaces
             WHERE name = :name
             """

--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -256,8 +256,7 @@ class DbRecorder(DbCodeGate):
         It may raise a ValidationError if the workspace name is invalid.
         or a AlreadyExistsError if the workspace already exists.
         """
-        workspace = Workspace(id=str(uuid.uuid4()), name=workspace_name)
-
+        workspace = Workspace(id=str(uuid.uuid4()), name=workspace_name, system_prompt=None)
         sql = text(
             """
             INSERT INTO workspaces (id, name)

--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -248,7 +248,7 @@ class DbRecorder(DbCodeGate):
         except Exception as e:
             logger.error(f"Failed to record context: {context}.", error=str(e))
 
-    async def add_workspace(self, workspace_name: str) -> Optional[Workspace]:
+    async def add_workspace(self, workspace_name: str) -> Workspace:
         """Add a new workspace to the DB.
 
         This handles validation and insertion of a new workspace.
@@ -274,7 +274,7 @@ class DbRecorder(DbCodeGate):
             raise AlreadyExistsError(f"Workspace {workspace_name} already exists.")
         return added_workspace
 
-    async def update_workspace(self, workspace: Workspace) -> Optional[Workspace]:
+    async def update_workspace(self, workspace: Workspace) -> Workspace:
         sql = text(
             """
             UPDATE workspaces SET
@@ -284,8 +284,7 @@ class DbRecorder(DbCodeGate):
             RETURNING *
             """
         )
-        # We only pass an object to respect the signature of the function
-        updated_workspace = await self._execute_update_pydantic_model(workspace, sql)
+        updated_workspace = await self._execute_update_pydantic_model(workspace, sql, should_raise=True)
         return updated_workspace
 
     async def update_session(self, session: Session) -> Optional[Session]:

--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -436,7 +436,7 @@ class DbReader(DbCodeGate):
         sql = text(
             """
             SELECT
-                w.id, w.name, s.id as session_id, s.last_update
+                w.id, w.name, w.system_prompt, s.id as session_id, s.last_update
             FROM sessions s
             INNER JOIN workspaces w ON w.id = s.active_workspace_id
             """

--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -284,7 +284,9 @@ class DbRecorder(DbCodeGate):
             RETURNING *
             """
         )
-        updated_workspace = await self._execute_update_pydantic_model(workspace, sql, should_raise=True)
+        updated_workspace = await self._execute_update_pydantic_model(
+            workspace, sql, should_raise=True
+        )
         return updated_workspace
 
     async def update_session(self, session: Session) -> Optional[Session]:

--- a/src/codegate/db/models.py
+++ b/src/codegate/db/models.py
@@ -43,12 +43,18 @@ class Setting(BaseModel):
 class Workspace(BaseModel):
     id: str
     name: str
+    system_prompt: Optional[str]
 
     @field_validator("name", mode="plain")
     @classmethod
-    def name_must_be_alphanumeric(cls, value):
+    def validate_name(cls, value):
         if not re.match(r"^[a-zA-Z0-9_-]+$", value):
             raise ValueError("name must be alphanumeric and can only contain _ and -")
+        # Avoid workspace names that are the same as commands that way we can do stuff like
+        # `codegate workspace list` and
+        # `codegate workspace my-ws system-prompt` without any conflicts
+        elif value in ["list", "add", "activate", "system-prompt"]:
+            raise ValueError("name cannot be the same as a command")
         return value
 
 

--- a/src/codegate/db/models.py
+++ b/src/codegate/db/models.py
@@ -47,7 +47,7 @@ class Workspace(BaseModel):
 
     @field_validator("name", mode="plain")
     @classmethod
-    def validate_name(cls, value):
+    def name_must_be_alphanumeric(cls, value):
         if not re.match(r"^[a-zA-Z0-9_-]+$", value):
             raise ValueError("name must be alphanumeric and can only contain _ and -")
         return value

--- a/src/codegate/db/models.py
+++ b/src/codegate/db/models.py
@@ -50,11 +50,6 @@ class Workspace(BaseModel):
     def validate_name(cls, value):
         if not re.match(r"^[a-zA-Z0-9_-]+$", value):
             raise ValueError("name must be alphanumeric and can only contain _ and -")
-        # Avoid workspace names that are the same as commands that way we can do stuff like
-        # `codegate workspace list` and
-        # `codegate workspace my-ws system-prompt` without any conflicts
-        elif value in ["list", "add", "activate", "system-prompt"]:
-            raise ValueError("name cannot be the same as a command")
         return value
 
 
@@ -104,5 +99,6 @@ class WorkspaceActive(BaseModel):
 class ActiveWorkspace(BaseModel):
     id: str
     name: str
+    system_prompt: Optional[str]
     session_id: str
     last_update: datetime.datetime

--- a/src/codegate/pipeline/cli/cli.py
+++ b/src/codegate/pipeline/cli/cli.py
@@ -8,7 +8,7 @@ from codegate.pipeline.base import (
     PipelineResult,
     PipelineStep,
 )
-from codegate.pipeline.cli.commands import Version, Workspace
+from codegate.pipeline.cli.commands import SystemPrompt, Version, Workspace
 
 HELP_TEXT = """
 ## CodeGate CLI\n
@@ -32,6 +32,7 @@ async def codegate_cli(command):
     available_commands = {
         "version": Version().exec,
         "workspace": Workspace().exec,
+        "system-prompt": SystemPrompt().exec,
     }
     out_func = available_commands.get(command[0])
     if out_func is None:

--- a/src/codegate/pipeline/cli/commands.py
+++ b/src/codegate/pipeline/cli/commands.py
@@ -104,6 +104,18 @@ class Workspace(CodegateCommand):
             return "An error occurred while activating the workspace"
         return f"Workspace **{workspace_name}** has been activated"
 
+    async def _add_system_prompt(self, workspace_name: str, sys_prompt_lst: List[str]):
+        updated_worksapce = await self.workspace_crud.update_workspace_system_prompt(workspace_name, sys_prompt_lst)
+        if not updated_worksapce:
+            return (
+                f"Workspace system prompt not updated. "
+                f"Check if the workspace **{workspace_name}** exists"
+            )
+        return (
+            f"Workspace **{updated_worksapce.name}** system prompt "
+            f"updated to:\n\n```{updated_worksapce.system_prompt}```"
+        )
+
     async def run(self, args: List[str]) -> str:
         if not args:
             return "Please provide a command. Use `codegate workspace -h` to see available commands"
@@ -112,6 +124,8 @@ class Workspace(CodegateCommand):
         if command_to_execute is not None:
             return await command_to_execute(args[1:])
         else:
+            if len(args) >= 2 and args[1] == "system-prompt":
+                return await self._add_system_prompt(args[0], args[2:])
             return "Command not found. Use `codegate workspace -h` to see available commands"
 
     @property

--- a/src/codegate/pipeline/cli/commands.py
+++ b/src/codegate/pipeline/cli/commands.py
@@ -31,10 +31,10 @@ class Version(CodegateCommand):
     @property
     def help(self) -> str:
         return (
-            "### CodeGate Version\n\n"
+            "### CodeGate Version\n"
             "Prints the version of CodeGate.\n\n"
+            "*args*: None\n\n"
             "**Usage**: `codegate version`\n\n"
-            "*args*: None"
         )
 
 
@@ -46,6 +46,7 @@ class Workspace(CodegateCommand):
             "list": self._list_workspaces,
             "add": self._add_workspace,
             "activate": self._activate_workspace,
+            "system-prompt": self._add_system_prompt,
         }
 
     async def _list_workspaces(self, *args: List[str]) -> str:
@@ -66,33 +67,33 @@ class Workspace(CodegateCommand):
         Add a workspace
         """
         if args is None or len(args) == 0:
-            return "Please provide a name. Use `codegate workspace add your_workspace_name`"
+            return "Please provide a name. Use `codegate workspace add <workspace_name>`"
 
         new_workspace_name = args[0]
         if not new_workspace_name:
-            return "Please provide a name. Use `codegate workspace add your_workspace_name`"
+            return "Please provide a name. Use `codegate workspace add <workspace_name>`"
 
         try:
             _ = await self.workspace_crud.add_workspace(new_workspace_name)
         except ValidationError:
             return "Invalid workspace name: It should be alphanumeric and dashes"
         except AlreadyExistsError:
-            return f"Workspace **{new_workspace_name}** already exists"
+            return f"Workspace `{new_workspace_name}` already exists"
         except Exception:
             return "An error occurred while adding the workspace"
 
-        return f"Workspace **{new_workspace_name}** has been added"
+        return f"Workspace `{new_workspace_name}` has been added"
 
     async def _activate_workspace(self, args: List[str]) -> str:
         """
         Activate a workspace
         """
         if args is None or len(args) == 0:
-            return "Please provide a name. Use `codegate workspace activate workspace_name`"
+            return "Please provide a name. Use `codegate workspace activate <workspace_name>`"
 
         workspace_name = args[0]
         if not workspace_name:
-            return "Please provide a name. Use `codegate workspace activate workspace_name`"
+            return "Please provide a name. Use `codegate workspace activate <workspace_name>`"
 
         try:
             await self.workspace_crud.activate_workspace(workspace_name)
@@ -104,16 +105,27 @@ class Workspace(CodegateCommand):
             return "An error occurred while activating the workspace"
         return f"Workspace **{workspace_name}** has been activated"
 
-    async def _add_system_prompt(self, workspace_name: str, sys_prompt_lst: List[str]):
-        updated_worksapce = await self.workspace_crud.update_workspace_system_prompt(workspace_name, sys_prompt_lst)
+    async def _add_system_prompt(self, args: List[str]):
+        if len(args) < 2:
+            return (
+                "Please provide a workspace name and a system prompt. "
+                "Use `codegate workspace system-prompt <workspace_name> <system_prompt>`"
+            )
+
+        workspace_name = args[0]
+        sys_prompt_lst = args[1:]
+
+        updated_worksapce = await self.workspace_crud.update_workspace_system_prompt(
+            workspace_name, sys_prompt_lst
+        )
         if not updated_worksapce:
             return (
                 f"Workspace system prompt not updated. "
-                f"Check if the workspace **{workspace_name}** exists"
+                f"Check if the workspace `{workspace_name}` exists"
             )
         return (
-            f"Workspace **{updated_worksapce.name}** system prompt "
-            f"updated to:\n\n```{updated_worksapce.system_prompt}```"
+            f"Workspace `{updated_worksapce.name}` system prompt "
+            f"updated to:\n```\n{updated_worksapce.system_prompt}\n```"
         )
 
     async def run(self, args: List[str]) -> str:
@@ -124,23 +136,29 @@ class Workspace(CodegateCommand):
         if command_to_execute is not None:
             return await command_to_execute(args[1:])
         else:
-            if len(args) >= 2 and args[1] == "system-prompt":
-                return await self._add_system_prompt(args[0], args[2:])
             return "Command not found. Use `codegate workspace -h` to see available commands"
 
     @property
     def help(self) -> str:
         return (
-            "### CodeGate Workspace\n\n"
+            "### CodeGate Workspace\n"
             "Manage workspaces.\n\n"
             "**Usage**: `codegate workspace <command> [args]`\n\n"
-            "Available commands:\n\n"
-            "- `list`: List all workspaces\n\n"
-            "  - *args*: None\n\n"
-            "- `add`: Add a workspace\n\n"
-            "  - *args*:\n\n"
-            "    - `workspace_name`\n\n"
-            "- `activate`: Activate a workspace\n\n"
-            "  - *args*:\n\n"
-            "    - `workspace_name`"
+            "Available commands:\n"
+            "- `list`: List all workspaces\n"
+            "  - *args*: None\n"
+            "  - **Usage**: `codegate workspace list`\n"
+            "- `add`: Add a workspace\n"
+            "  - *args*:\n"
+            "    - `workspace_name`\n"
+            "  - **Usage**: `codegate workspace add <workspace_name>`\n"
+            "- `activate`: Activate a workspace\n"
+            "  - *args*:\n"
+            "    - `workspace_name`\n"
+            "  - **Usage**: `codegate workspace activate <workspace_name>`\n"
+            "- `system-prompt`: Modify the system-prompt of a workspace\n"
+            "  - *args*:\n"
+            "    - `workspace_name`\n"
+            "    - `system_prompt`\n"
+            "  - **Usage**: `codegate workspace system-prompt <workspace_name> <system_prompt>`\n"
         )

--- a/src/codegate/pipeline/cli/commands.py
+++ b/src/codegate/pipeline/cli/commands.py
@@ -230,6 +230,7 @@ class SystemPrompt(CodegateCommandSubcommand):
     def subcommands(self) -> Dict[str, Callable[[List[str]], Awaitable[str]]]:
         return {
             "set": self._set_system_prompt,
+            "show": self._show_system_prompt,
         }
 
     async def _set_system_prompt(self, flags: Dict[str, str], args: List[str]) -> str:
@@ -253,10 +254,22 @@ class SystemPrompt(CodegateCommandSubcommand):
                 f"Workspace system prompt not updated. Workspace `{workspace_name}` doesn't exist"
             )
 
-        return (
-            f"Workspace `{updated_worksapce.name}` system prompt "
-            f"updated to:\n```\n{updated_worksapce.system_prompt}\n```"
-        )
+        return f"Workspace `{updated_worksapce.name}` system prompt updated."
+
+    async def _show_system_prompt(self, flags: Dict[str, str], args: List[str]) -> str:
+        workspace_name = flags.get("-w")
+        if not workspace_name:
+            active_workspace = await self.workspace_crud.get_active_workspace()
+            workspace_name = active_workspace.name
+
+        try:
+            workspace = await self.workspace_crud.get_workspace_by_name(workspace_name)
+        except crud.WorkspaceDoesNotExistError:
+            return (
+                f"Workspace `{workspace_name}` doesn't exist"
+            )
+
+        return f"Workspace **{workspace.name}** system prompt:\n\n{workspace.system_prompt}."
 
     @property
     def help(self) -> str:

--- a/src/codegate/pipeline/cli/commands.py
+++ b/src/codegate/pipeline/cli/commands.py
@@ -11,8 +11,10 @@ from codegate.workspaces import crud
 class NoFlagValueError(Exception):
     pass
 
+
 class NoSubcommandError(Exception):
     pass
+
 
 class CodegateCommand(ABC):
     @abstractmethod
@@ -46,10 +48,10 @@ class Version(CodegateCommand):
     @property
     def help(self) -> str:
         return (
-            "### CodeGate Version\n"
+            "### CodeGate Version\n\n"
             "Prints the version of CodeGate.\n\n"
-            "*args*: None\n\n"
             "**Usage**: `codegate version`\n\n"
+            "*args*: None"
         )
 
 
@@ -74,7 +76,7 @@ class CodegateCommandSubcommand(CodegateCommand):
                 flag_name = args[i]
                 if i + 1 >= len(args):
                     raise NoFlagValueError(f"Flag {flag_name} needs a value, but none provided.")
-                read_flags[flag_name] = args[i+1]
+                read_flags[flag_name] = args[i + 1]
                 i += 2
             else:
                 # Once we encounter something that's not a recognized flag,
@@ -165,11 +167,11 @@ class Workspace(CodegateCommandSubcommand):
         except ValidationError:
             return "Invalid workspace name: It should be alphanumeric and dashes"
         except AlreadyExistsError:
-            return f"Workspace `{new_workspace_name}` already exists"
+            return f"Workspace **{new_workspace_name}** already exists"
         except Exception:
             return "An error occurred while adding the workspace"
 
-        return f"Workspace `{new_workspace_name}` has been added"
+        return f"Workspace **{new_workspace_name}** has been added"
 
     async def _activate_workspace(self, flags: Dict[str, str], args: List[str]) -> str:
         """
@@ -195,21 +197,18 @@ class Workspace(CodegateCommandSubcommand):
     @property
     def help(self) -> str:
         return (
-            "### CodeGate Workspace\n"
+            "### CodeGate Workspace\n\n"
             "Manage workspaces.\n\n"
             "**Usage**: `codegate workspace <command> [args]`\n\n"
-            "Available commands:\n"
-            "- `list`: List all workspaces\n"
-            "  - *args*: None\n"
-            "  - **Usage**: `codegate workspace list`\n"
-            "- `add`: Add a workspace\n"
-            "  - *args*:\n"
-            "    - `workspace_name`\n"
-            "  - **Usage**: `codegate workspace add <workspace_name>`\n"
-            "- `activate`: Activate a workspace\n"
-            "  - *args*:\n"
-            "    - `workspace_name`\n"
-            "  - **Usage**: `codegate workspace activate <workspace_name>`\n"
+            "Available commands:\n\n"
+            "- `list`: List all workspaces\n\n"
+            "  - *args*: None\n\n"
+            "- `add`: Add a workspace\n\n"
+            "  - *args*:\n\n"
+            "    - `workspace_name`\n\n"
+            "- `activate`: Activate a workspace\n\n"
+            "  - *args*:\n\n"
+            "    - `workspace_name`"
         )
 
 
@@ -265,9 +264,7 @@ class SystemPrompt(CodegateCommandSubcommand):
         try:
             workspace = await self.workspace_crud.get_workspace_by_name(workspace_name)
         except crud.WorkspaceDoesNotExistError:
-            return (
-                f"Workspace `{workspace_name}` doesn't exist"
-            )
+            return f"Workspace `{workspace_name}` doesn't exist"
 
         return f"Workspace **{workspace.name}** system prompt:\n\n{workspace.system_prompt}."
 

--- a/src/codegate/pipeline/cli/commands.py
+++ b/src/codegate/pipeline/cli/commands.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import Awaitable, Callable, Dict, List, Tuple
 
 from pydantic import ValidationError
 
@@ -8,9 +8,20 @@ from codegate.db.connection import AlreadyExistsError
 from codegate.workspaces import crud
 
 
+class NoFlagValueError(Exception):
+    pass
+
+class NoSubcommandError(Exception):
+    pass
+
 class CodegateCommand(ABC):
     @abstractmethod
     async def run(self, args: List[str]) -> str:
+        pass
+
+    @property
+    @abstractmethod
+    def command_name(self) -> str:
         pass
 
     @property
@@ -19,7 +30,7 @@ class CodegateCommand(ABC):
         pass
 
     async def exec(self, args: List[str]) -> str:
-        if args and args[0] == "-h":
+        if len(args) > 0 and args[0] == "-h":
             return self.help
         return await self.run(args)
 
@@ -27,6 +38,10 @@ class CodegateCommand(ABC):
 class Version(CodegateCommand):
     async def run(self, args: List[str]) -> str:
         return f"CodeGate version: {__version__}"
+
+    @property
+    def command_name(self) -> str:
+        return "version"
 
     @property
     def help(self) -> str:
@@ -38,18 +53,90 @@ class Version(CodegateCommand):
         )
 
 
-class Workspace(CodegateCommand):
+class CodegateCommandSubcommand(CodegateCommand):
+
+    @property
+    @abstractmethod
+    def subcommands(self) -> Dict[str, Callable[[List[str]], Awaitable[str]]]:
+        pass
+
+    @property
+    @abstractmethod
+    def flags(self) -> List[str]:
+        pass
+
+    def _parse_flags_and_subocomand(self, args: List[str]) -> Tuple[Dict[str, str], List[str], str]:
+        i = 0
+        read_flags = {}
+        # Parse all recognized flags at the start
+        while i < len(args):
+            if args[i] in self.flags:
+                flag_name = args[i]
+                if i + 1 >= len(args):
+                    raise NoFlagValueError(f"Flag {flag_name} needs a value, but none provided.")
+                read_flags[flag_name] = args[i+1]
+                i += 2
+            else:
+                # Once we encounter something that's not a recognized flag,
+                # we assume it's the subcommand
+                break
+
+        if i >= len(args):
+            raise NoSubcommandError("No subcommand found after optional flags.")
+
+        subcommand = args[i]
+        i += 1
+
+        # The rest of the arguments after the subcommand
+        rest = args[i:]
+        return read_flags, rest, subcommand
+
+    async def run(self, args: List[str]) -> str:
+        try:
+            flags, rest, subcommand = self._parse_flags_and_subocomand(args)
+        except NoFlagValueError:
+            return (
+                f"Error reading the command. Flag without value found. "
+                f"Use `codegate {self.command_name} -h` to see available subcommands"
+            )
+        except NoSubcommandError:
+            return (
+                f"Submmand not found "
+                f"Use `codegate {self.command_name} -h` to see available subcommands"
+            )
+
+        command_to_execute = self.subcommands.get(subcommand)
+        if command_to_execute is None:
+            return (
+                f"Submmand not found "
+                f"Use `codegate {self.command_name} -h` to see available subcommands"
+            )
+
+        return await command_to_execute(flags, rest)
+
+
+class Workspace(CodegateCommandSubcommand):
 
     def __init__(self):
         self.workspace_crud = crud.WorkspaceCrud()
-        self.commands = {
+
+    @property
+    def command_name(self) -> str:
+        return "workspace"
+
+    @property
+    def flags(self) -> List[str]:
+        return []
+
+    @property
+    def subcommands(self) -> Dict[str, Callable[[List[str]], Awaitable[str]]]:
+        return {
             "list": self._list_workspaces,
             "add": self._add_workspace,
             "activate": self._activate_workspace,
-            "system-prompt": self._add_system_prompt,
         }
 
-    async def _list_workspaces(self, *args: List[str]) -> str:
+    async def _list_workspaces(self, flags: Dict[str, str], args: List[str]) -> str:
         """
         List all workspaces
         """
@@ -62,7 +149,7 @@ class Workspace(CodegateCommand):
             respond_str += "\n"
         return respond_str
 
-    async def _add_workspace(self, args: List[str]) -> str:
+    async def _add_workspace(self, flags: Dict[str, str], args: List[str]) -> str:
         """
         Add a workspace
         """
@@ -84,7 +171,7 @@ class Workspace(CodegateCommand):
 
         return f"Workspace `{new_workspace_name}` has been added"
 
-    async def _activate_workspace(self, args: List[str]) -> str:
+    async def _activate_workspace(self, flags: Dict[str, str], args: List[str]) -> str:
         """
         Activate a workspace
         """
@@ -105,39 +192,6 @@ class Workspace(CodegateCommand):
             return "An error occurred while activating the workspace"
         return f"Workspace **{workspace_name}** has been activated"
 
-    async def _add_system_prompt(self, args: List[str]):
-        if len(args) < 2:
-            return (
-                "Please provide a workspace name and a system prompt. "
-                "Use `codegate workspace system-prompt <workspace_name> <system_prompt>`"
-            )
-
-        workspace_name = args[0]
-        sys_prompt_lst = args[1:]
-
-        updated_worksapce = await self.workspace_crud.update_workspace_system_prompt(
-            workspace_name, sys_prompt_lst
-        )
-        if not updated_worksapce:
-            return (
-                f"Workspace system prompt not updated. "
-                f"Check if the workspace `{workspace_name}` exists"
-            )
-        return (
-            f"Workspace `{updated_worksapce.name}` system prompt "
-            f"updated to:\n```\n{updated_worksapce.system_prompt}\n```"
-        )
-
-    async def run(self, args: List[str]) -> str:
-        if not args:
-            return "Please provide a command. Use `codegate workspace -h` to see available commands"
-        command = args[0]
-        command_to_execute = self.commands.get(command)
-        if command_to_execute is not None:
-            return await command_to_execute(args[1:])
-        else:
-            return "Command not found. Use `codegate workspace -h` to see available commands"
-
     @property
     def help(self) -> str:
         return (
@@ -156,9 +210,65 @@ class Workspace(CodegateCommand):
             "  - *args*:\n"
             "    - `workspace_name`\n"
             "  - **Usage**: `codegate workspace activate <workspace_name>`\n"
-            "- `system-prompt`: Modify the system-prompt of a workspace\n"
+        )
+
+
+class SystemPrompt(CodegateCommandSubcommand):
+
+    def __init__(self):
+        self.workspace_crud = crud.WorkspaceCrud()
+
+    @property
+    def command_name(self) -> str:
+        return "system-prompt"
+
+    @property
+    def flags(self) -> List[str]:
+        return ["-w"]
+
+    @property
+    def subcommands(self) -> Dict[str, Callable[[List[str]], Awaitable[str]]]:
+        return {
+            "set": self._set_system_prompt,
+        }
+
+    async def _set_system_prompt(self, flags: Dict[str, str], args: List[str]) -> str:
+        if len(args) == 0:
+            return (
+                "Please provide a workspace name and a system prompt. "
+                "Use `codegate workspace system-prompt -w <workspace_name> <system_prompt>`"
+            )
+
+        workspace_name = flags.get("-w")
+        if not workspace_name:
+            active_workspace = await self.workspace_crud.get_active_workspace()
+            workspace_name = active_workspace.name
+
+        updated_worksapce = await self.workspace_crud.update_workspace_system_prompt(
+            workspace_name, args
+        )
+        if not updated_worksapce:
+            return (
+                f"Workspace system prompt not updated. "
+                f"Check if the workspace `{workspace_name}` exists"
+            )
+        return (
+            f"Workspace `{updated_worksapce.name}` system prompt "
+            f"updated to:\n```\n{updated_worksapce.system_prompt}\n```"
+        )
+
+    @property
+    def help(self) -> str:
+        return (
+            "### CodeGate System Prompt\n"
+            "Manage the system prompts of workspaces.\n\n"
+            "**Usage**: `codegate system-prompt -w <workspace_name> <command>`\n\n"
+            "*args*:\n"
+            "- `workspace_name`: Optional workspace name. If not specified will use the "
+            "active workspace\n\n"
+            "Available commands:\n"
+            "- `set`: Set the system prompt of the workspace\n"
             "  - *args*:\n"
-            "    - `workspace_name`\n"
-            "    - `system_prompt`\n"
-            "  - **Usage**: `codegate workspace system-prompt <workspace_name> <system_prompt>`\n"
+            "    - `system_prompt`: The system prompt to set\n"
+            "  - **Usage**: `codegate system-prompt -w <workspace_name> set <system_prompt>`\n"
         )

--- a/src/codegate/pipeline/cli/commands.py
+++ b/src/codegate/pipeline/cli/commands.py
@@ -156,11 +156,11 @@ class Workspace(CodegateCommandSubcommand):
         Add a workspace
         """
         if args is None or len(args) == 0:
-            return "Please provide a name. Use `codegate workspace add <workspace_name>`"
+            return "Please provide a name. Use `codegate workspace add your_workspace_name`"
 
         new_workspace_name = args[0]
         if not new_workspace_name:
-            return "Please provide a name. Use `codegate workspace add <workspace_name>`"
+            return "Please provide a name. Use `codegate workspace add your_workspace_name`"
 
         try:
             _ = await self.workspace_crud.add_workspace(new_workspace_name)
@@ -178,11 +178,11 @@ class Workspace(CodegateCommandSubcommand):
         Activate a workspace
         """
         if args is None or len(args) == 0:
-            return "Please provide a name. Use `codegate workspace activate <workspace_name>`"
+            return "Please provide a name. Use `codegate workspace activate workspace_name`"
 
         workspace_name = args[0]
         if not workspace_name:
-            return "Please provide a name. Use `codegate workspace activate <workspace_name>`"
+            return "Please provide a name. Use `codegate workspace activate workspace_name`"
 
         try:
             await self.workspace_crud.activate_workspace(workspace_name)

--- a/src/codegate/pipeline/cli/commands.py
+++ b/src/codegate/pipeline/cli/commands.py
@@ -244,14 +244,15 @@ class SystemPrompt(CodegateCommandSubcommand):
             active_workspace = await self.workspace_crud.get_active_workspace()
             workspace_name = active_workspace.name
 
-        updated_worksapce = await self.workspace_crud.update_workspace_system_prompt(
-            workspace_name, args
-        )
-        if not updated_worksapce:
-            return (
-                f"Workspace system prompt not updated. "
-                f"Check if the workspace `{workspace_name}` exists"
+        try:
+            updated_worksapce = await self.workspace_crud.update_workspace_system_prompt(
+                workspace_name, args
             )
+        except crud.WorkspaceDoesNotExistError:
+            return (
+                f"Workspace system prompt not updated. Workspace `{workspace_name}` doesn't exist"
+            )
+
         return (
             f"Workspace `{updated_worksapce.name}` system prompt "
             f"updated to:\n```\n{updated_worksapce.system_prompt}\n```"

--- a/src/codegate/workspaces/crud.py
+++ b/src/codegate/workspaces/crud.py
@@ -84,8 +84,8 @@ class WorkspaceCrud:
         return
 
     async def update_workspace_system_prompt(
-            self, workspace_name: str, sys_prompt_lst: List[str]
-        ) -> Optional[Workspace]:
+        self, workspace_name: str, sys_prompt_lst: List[str]
+    ) -> Optional[Workspace]:
         selected_workspace = await self._db_reader.get_workspace_by_name(workspace_name)
         if not selected_workspace:
             return None

--- a/src/codegate/workspaces/crud.py
+++ b/src/codegate/workspaces/crud.py
@@ -85,10 +85,10 @@ class WorkspaceCrud:
 
     async def update_workspace_system_prompt(
         self, workspace_name: str, sys_prompt_lst: List[str]
-    ) -> Optional[Workspace]:
+    ) -> Workspace:
         selected_workspace = await self._db_reader.get_workspace_by_name(workspace_name)
         if not selected_workspace:
-            return None
+            raise WorkspaceDoesNotExistError(f"Workspace {workspace_name} does not exist.")
 
         system_prompt = " ".join(sys_prompt_lst)
         workspace_update = Workspace(

--- a/src/codegate/workspaces/crud.py
+++ b/src/codegate/workspaces/crud.py
@@ -60,7 +60,7 @@ class WorkspaceCrud:
         sessions = await self._db_reader.get_sessions()
         # The current implementation expects only one active session
         if len(sessions) != 1:
-            raise RuntimeError("Something went wrong. No active session found.")
+            raise WorkspaceCrudError("Something went wrong. More than one session found.")
 
         session = sessions[0]
         return (session.active_workspace_id == selected_workspace.id, session, selected_workspace)
@@ -82,3 +82,20 @@ class WorkspaceCrud:
         db_recorder = DbRecorder()
         await db_recorder.update_session(session)
         return
+
+    async def update_workspace_system_prompt(
+            self, workspace_name: str, sys_prompt_lst: List[str]
+        ) -> Optional[Workspace]:
+        selected_workspace = await self._db_reader.get_workspace_by_name(workspace_name)
+        if not selected_workspace:
+            return None
+
+        system_prompt = " ".join(sys_prompt_lst)
+        workspace_update = Workspace(
+            id=selected_workspace.id,
+            name=selected_workspace.name,
+            system_prompt=system_prompt,
+        )
+        db_recorder = DbRecorder()
+        updated_workspace = await db_recorder.update_workspace(workspace_update)
+        return updated_workspace

--- a/src/codegate/workspaces/crud.py
+++ b/src/codegate/workspaces/crud.py
@@ -99,3 +99,9 @@ class WorkspaceCrud:
         db_recorder = DbRecorder()
         updated_workspace = await db_recorder.update_workspace(workspace_update)
         return updated_workspace
+
+    async def get_workspace_by_name(self, workspace_name: str) -> Workspace:
+        workspace = await self._db_reader.get_workspace_by_name(workspace_name)
+        if not workspace:
+            raise WorkspaceDoesNotExistError(f"Workspace {workspace_name} does not exist.")
+        return workspace

--- a/tests/pipeline/system_prompt/test_system_prompt.py
+++ b/tests/pipeline/system_prompt/test_system_prompt.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from litellm.types.llms.openai import ChatCompletionRequest
@@ -14,7 +14,7 @@ class TestSystemPrompt:
         """
         test_message = "Test system prompt"
         step = SystemPrompt(system_prompt=test_message)
-        assert step._system_message["content"] == test_message
+        assert step.codegate_system_prompt == test_message
 
     @pytest.mark.asyncio
     async def test_process_system_prompt_insertion(self):
@@ -29,6 +29,7 @@ class TestSystemPrompt:
         # Create system prompt step
         system_prompt = "Security analysis system prompt"
         step = SystemPrompt(system_prompt=system_prompt)
+        step._get_workspace_system_prompt = AsyncMock(return_value="")
 
         # Mock the get_last_user_message method
         step.get_last_user_message = Mock(return_value=(user_message, 0))
@@ -62,6 +63,7 @@ class TestSystemPrompt:
         # Create system prompt step
         system_prompt = "Security analysis system prompt"
         step = SystemPrompt(system_prompt=system_prompt)
+        step._get_workspace_system_prompt = AsyncMock(return_value="")
 
         # Mock the get_last_user_message method
         step.get_last_user_message = Mock(return_value=(user_message, 0))
@@ -74,7 +76,7 @@ class TestSystemPrompt:
         assert result.request["messages"][0]["role"] == "system"
         assert (
             result.request["messages"][0]["content"]
-            == system_prompt + "\n Here are additional instructions. \n " + request_system_message
+            == system_prompt + "\n\nHere are additional instructions:\n\n" + request_system_message
         )
         assert result.request["messages"][1]["role"] == "user"
         assert result.request["messages"][1]["content"] == user_message
@@ -96,6 +98,7 @@ class TestSystemPrompt:
 
         system_prompt = "Security edge case prompt"
         step = SystemPrompt(system_prompt=system_prompt)
+        step._get_workspace_system_prompt = AsyncMock(return_value="")
 
         # Mock get_last_user_message to return None
         step.get_last_user_message = Mock(return_value=None)

--- a/tests/pipeline/workspace/test_workspace.py
+++ b/tests/pipeline/workspace/test_workspace.py
@@ -42,7 +42,7 @@ async def test_list_workspaces(mock_workspaces, expected_output):
     workspace_commands.workspace_crud.get_workspaces = mock_get_workspaces
 
     # Call the method
-    result = await workspace_commands._list_workspaces()
+    result = await workspace_commands._list_workspaces(None, None)
 
     # Check the result
     assert result == expected_output
@@ -54,11 +54,11 @@ async def test_list_workspaces(mock_workspaces, expected_output):
     "args, existing_workspaces, expected_message",
     [
         # Case 1: No workspace name provided
-        ([], [], "Please provide a name. Use `codegate workspace add <workspace_name>`"),
+        ([], [], "Please provide a name. Use `codegate workspace add your_workspace_name`"),
         # Case 2: Workspace name is empty string
-        ([""], [], "Please provide a name. Use `codegate workspace add <workspace_name>`"),
+        ([""], [], "Please provide a name. Use `codegate workspace add your_workspace_name`"),
         # Case 3: Successful add
-        (["myworkspace"], [], "Workspace `myworkspace` has been added"),
+        (["myworkspace"], [], "Workspace **myworkspace** has been added"),
     ],
 )
 async def test_add_workspaces(args, existing_workspaces, expected_message):
@@ -83,7 +83,7 @@ async def test_add_workspaces(args, existing_workspaces, expected_message):
         mock_recorder.add_workspace = AsyncMock()
 
         # Call the method
-        result = await workspace_commands._add_workspace(args)
+        result = await workspace_commands._add_workspace(None, args)
 
         # Assertions
         assert result == expected_message

--- a/tests/pipeline/workspace/test_workspace.py
+++ b/tests/pipeline/workspace/test_workspace.py
@@ -54,11 +54,11 @@ async def test_list_workspaces(mock_workspaces, expected_output):
     "args, existing_workspaces, expected_message",
     [
         # Case 1: No workspace name provided
-        ([], [], "Please provide a name. Use `codegate workspace add your_workspace_name`"),
+        ([], [], "Please provide a name. Use `codegate workspace add <workspace_name>`"),
         # Case 2: Workspace name is empty string
-        ([""], [], "Please provide a name. Use `codegate workspace add your_workspace_name`"),
+        ([""], [], "Please provide a name. Use `codegate workspace add <workspace_name>`"),
         # Case 3: Successful add
-        (["myworkspace"], [], "Workspace **myworkspace** has been added"),
+        (["myworkspace"], [], "Workspace `myworkspace` has been added"),
     ],
 )
 async def test_add_workspaces(args, existing_workspaces, expected_message):


### PR DESCRIPTION
Related: #454

This PR introduces being able to add system-prompts to workspaces. The workspace system prompts are added in the step that we are using to add CodeGate system prompt. The order of the prompts will be the following assuming all of them are present:
- CodeGate system prompt
- Workspace system prompt
- Request system prompt

The corresponding CLI command is also created and the documentation in the CLI is updated