### PR TITLE
Implement basic soft deletion for workspaces

### DIFF
--- a/migrations/versions/8e4b4b8d1a88_add_soft_delete.py
+++ b/migrations/versions/8e4b4b8d1a88_add_soft_delete.py
@@ -1,0 +1,30 @@
+"""add soft delete
+
+Revision ID: 8e4b4b8d1a88
+Revises: 5c2f3eee5f90
+Create Date: 2025-01-20 14:08:40.851647
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "8e4b4b8d1a88"
+down_revision: Union[str, None] = "5c2f3eee5f90"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE workspaces
+        ADD COLUMN deleted_at DATETIME DEFAULT NULL;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE workspaces DROP COLUMN deleted_at;")

--- a/migrations/versions/e6227073183d_merging_system_prompt_and_soft_deletes.py
+++ b/migrations/versions/e6227073183d_merging_system_prompt_and_soft_deletes.py
@@ -1,0 +1,23 @@
+"""merging system prompt and soft-deletes
+
+Revision ID: e6227073183d
+Revises: 8e4b4b8d1a88, a692c8b52308
+Create Date: 2025-01-20 16:08:40.645298
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "e6227073183d"
+down_revision: Union[str, None] = ("8e4b4b8d1a88", "a692c8b52308")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/src/codegate/api/v1.py
+++ b/src/codegate/api/v1.py
@@ -79,8 +79,14 @@ async def create_workspace(request: v1_models.CreateWorkspaceRequest) -> v1_mode
     "/workspaces/{workspace_name}",
     tags=["Workspaces"],
     generate_unique_id_function=uniq_name,
-    status_code=204,
 )
 async def delete_workspace(workspace_name: str):
     """Delete a workspace by name."""
-    raise NotImplementedError
+    try:
+        _ = await wscrud.soft_delete_workspace(workspace_name)
+    except crud.WorkspaceDoesNotExistError:
+        return HTTPException(status_code=404, detail="Workspace does not exist")
+    except Exception:
+        return HTTPException(status_code=500, detail="Internal server error")
+
+    return Response(status_code=204)

--- a/src/codegate/api/v1.py
+++ b/src/codegate/api/v1.py
@@ -85,8 +85,8 @@ async def delete_workspace(workspace_name: str):
     try:
         _ = await wscrud.soft_delete_workspace(workspace_name)
     except crud.WorkspaceDoesNotExistError:
-        return HTTPException(status_code=404, detail="Workspace does not exist")
+        raise HTTPException(status_code=404, detail="Workspace does not exist")
     except Exception:
-        return HTTPException(status_code=500, detail="Internal server error")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
     return Response(status_code=204)

--- a/src/codegate/pipeline/cli/commands.py
+++ b/src/codegate/pipeline/cli/commands.py
@@ -212,7 +212,7 @@ class Workspace(CodegateCommandSubcommand):
             return "An error occurred while activating the workspace"
         return f"Workspace **{workspace_name}** has been activated"
 
-    async def _remove_workspace(self, args: List[str]) -> str:
+    async def _remove_workspace(self, flags: Dict[str, str], args: List[str]) -> str:
         """
         Remove a workspace
         """

--- a/src/codegate/pipeline/cli/commands.py
+++ b/src/codegate/pipeline/cli/commands.py
@@ -153,6 +153,7 @@ class Workspace(CodegateCommandSubcommand):
             "list": self._list_workspaces,
             "add": self._add_workspace,
             "activate": self._activate_workspace,
+            "remove": self._remove_workspace,
         }
 
     async def _list_workspaces(self, flags: Dict[str, str], args: List[str]) -> str:
@@ -210,6 +211,25 @@ class Workspace(CodegateCommandSubcommand):
         except Exception:
             return "An error occurred while activating the workspace"
         return f"Workspace **{workspace_name}** has been activated"
+
+    async def _remove_workspace(self, args: List[str]) -> str:
+        """
+        Remove a workspace
+        """
+        if args is None or len(args) == 0:
+            return "Please provide a name. Use `codegate workspace remove workspace_name`"
+
+        workspace_name = args[0]
+        if not workspace_name:
+            return "Please provide a name. Use `codegate workspace remove workspace_name`"
+
+        try:
+            await self.workspace_crud.soft_delete_workspace(workspace_name)
+        except crud.WorkspaceDoesNotExistError:
+            return f"Workspace **{workspace_name}** does not exist"
+        except Exception:
+            return "An error occurred while removing the workspace"
+        return f"Workspace **{workspace_name}** has been removed"
 
     @property
     def help(self) -> str:

--- a/src/codegate/workspaces/crud.py
+++ b/src/codegate/workspaces/crud.py
@@ -112,7 +112,7 @@ class WorkspaceCrud:
         # Check if workspace is active, if it is, make the default workspace active
         active_workspace = await self._db_reader.get_active_workspace()
         if active_workspace and active_workspace.id == selected_workspace.id:
-            _ = await self.activate_workspace("default")
+            raise WorkspaceCrudError("Cannot delete active workspace.")
 
         db_recorder = DbRecorder()
         try:

--- a/src/codegate/workspaces/crud.py
+++ b/src/codegate/workspaces/crud.py
@@ -68,10 +68,6 @@ class WorkspaceCrud:
     async def activate_workspace(self, workspace_name: str):
         """
         Activate a workspace
-
-        Will return:
-        - True if the workspace was activated
-        - False if the workspace is already active or does not exist
         """
         is_active, session, workspace = await self._is_workspace_active(workspace_name)
         if is_active:
@@ -99,6 +95,31 @@ class WorkspaceCrud:
         db_recorder = DbRecorder()
         updated_workspace = await db_recorder.update_workspace(workspace_update)
         return updated_workspace
+
+    async def soft_delete_workspace(self, workspace_name: str):
+        """
+        Soft delete a workspace
+        """
+        if workspace_name == "":
+            raise WorkspaceCrudError("Workspace name cannot be empty.")
+        if workspace_name == "default":
+            raise WorkspaceCrudError("Cannot delete default workspace.")
+
+        selected_workspace = await self._db_reader.get_workspace_by_name(workspace_name)
+        if not selected_workspace:
+            raise WorkspaceDoesNotExistError(f"Workspace {workspace_name} does not exist.")
+
+        # Check if workspace is active, if it is, make the default workspace active
+        active_workspace = await self._db_reader.get_active_workspace()
+        if active_workspace and active_workspace.id == selected_workspace.id:
+            _ = await self.activate_workspace("default")
+
+        db_recorder = DbRecorder()
+        try:
+            _ = await db_recorder.soft_delete_workspace(selected_workspace)
+        except Exception:
+            raise WorkspaceCrudError(f"Error deleting workspace {workspace_name}")
+        return
 
     async def get_workspace_by_name(self, workspace_name: str) -> Workspace:
         workspace = await self._db_reader.get_workspace_by_name(workspace_name)


### PR DESCRIPTION
this adds a `deleted_at` column to workspaces that implements a basic
soft-deletion mechanism. All relevant queries have been modified to reflect this.

At the moment, there is no hard deletion of workspaces; this will be
implemented in the future.

We also have no way of showing "archived" or "soft-deleted" workspaces.
This will come in due time.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
