### PR TITLE
Handle reserved keywords for workspaces

### DIFF
--- a/src/codegate/api/v1.py
+++ b/src/codegate/api/v1.py
@@ -69,6 +69,8 @@ async def create_workspace(request: v1_models.CreateWorkspaceRequest) -> v1_mode
                 "Invalid workspace name. " "Please use only alphanumeric characters and dashes"
             ),
         )
+    except crud.WorkspaceCrudError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception:
         raise HTTPException(status_code=500, detail="Internal server error")
 

--- a/src/codegate/pipeline/cli/commands.py
+++ b/src/codegate/pipeline/cli/commands.py
@@ -186,6 +186,8 @@ class Workspace(CodegateCommandSubcommand):
             return "Invalid workspace name: It should be alphanumeric and dashes"
         except AlreadyExistsError:
             return f"Workspace **{new_workspace_name}** already exists"
+        except crud.WorkspaceCrudError:
+            return "An error occurred while adding the workspace"
         except Exception:
             return "An error occurred while adding the workspace"
 

--- a/src/codegate/workspaces/crud.py
+++ b/src/codegate/workspaces/crud.py
@@ -17,6 +17,12 @@ class WorkspaceAlreadyActiveError(WorkspaceCrudError):
     pass
 
 
+DEFAULT_WORKSPACE_NAME = "default"
+
+# These are reserved keywords that cannot be used for workspaces
+RESERVED_WORKSPACE_KEYWORDS = [DEFAULT_WORKSPACE_NAME, "active"]
+
+
 class WorkspaceCrud:
 
     def __init__(self):
@@ -29,6 +35,10 @@ class WorkspaceCrud:
         Args:
             name (str): The name of the workspace
         """
+        if new_workspace_name == "":
+            raise WorkspaceCrudError("Workspace name cannot be empty.")
+        if new_workspace_name in RESERVED_WORKSPACE_KEYWORDS:
+            raise WorkspaceCrudError(f"Workspace name {new_workspace_name} is reserved.")
         db_recorder = DbRecorder()
         workspace_created = await db_recorder.add_workspace(new_workspace_name)
         return workspace_created
@@ -102,7 +112,7 @@ class WorkspaceCrud:
         """
         if workspace_name == "":
             raise WorkspaceCrudError("Workspace name cannot be empty.")
-        if workspace_name == "default":
+        if workspace_name == DEFAULT_WORKSPACE_NAME:
             raise WorkspaceCrudError("Cannot delete default workspace.")
 
         selected_workspace = await self._db_reader.get_workspace_by_name(workspace_name)


### PR DESCRIPTION
This disallows the creation of workspaces with the names "default" and
"active"

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
