### PR TITLE
Add constructs to rename workspaces

### DIFF
--- a/src/codegate/api/v1_models.py
+++ b/src/codegate/api/v1_models.py
@@ -48,8 +48,13 @@ class ListActiveWorkspacesResponse(pydantic.BaseModel):
         )
 
 
-class CreateWorkspaceRequest(pydantic.BaseModel):
+class CreateOrRenameWorkspaceRequest(pydantic.BaseModel):
     name: str
+
+    # If set, rename the workspace to this name. Note that
+    # the 'name' field is still required and the workspace
+    # workspace must exist.
+    rename_to: Optional[str] = None
 
 
 class ActivateWorkspaceRequest(pydantic.BaseModel):

--- a/src/codegate/pipeline/cli/commands.py
+++ b/src/codegate/pipeline/cli/commands.py
@@ -154,6 +154,7 @@ class Workspace(CodegateCommandSubcommand):
             "add": self._add_workspace,
             "activate": self._activate_workspace,
             "remove": self._remove_workspace,
+            "rename": self._rename_workspace,
         }
 
     async def _list_workspaces(self, flags: Dict[str, str], args: List[str]) -> str:
@@ -192,6 +193,37 @@ class Workspace(CodegateCommandSubcommand):
             return "An error occurred while adding the workspace"
 
         return f"Workspace **{new_workspace_name}** has been added"
+
+    async def _rename_workspace(self, flags: Dict[str, str], args: List[str]) -> str:
+        """
+        Rename a workspace
+        """
+        if args is None or len(args) < 2:
+            return (
+                "Please provide a name and a new name. "
+                "Use `codegate workspace rename workspace_name new_workspace_name`"
+            )
+
+        old_workspace_name = args[0]
+        new_workspace_name = args[1]
+        if not old_workspace_name or not new_workspace_name:
+            return (
+                "Please provide a name and a new name. "
+                "Use `codegate workspace rename workspace_name new_workspace_name`"
+            )
+
+        try:
+            await self.workspace_crud.rename_workspace(old_workspace_name, new_workspace_name)
+        except crud.WorkspaceDoesNotExistError:
+            return f"Workspace **{old_workspace_name}** does not exist"
+        except AlreadyExistsError:
+            return f"Workspace **{new_workspace_name}** already exists"
+        except crud.WorkspaceCrudError:
+            return "An error occurred while renaming the workspace"
+        except Exception:
+            return "An error occurred while renaming the workspace"
+
+        return f"Workspace **{old_workspace_name}** has been renamed to **{new_workspace_name}**"
 
     async def _activate_workspace(self, flags: Dict[str, str], args: List[str]) -> str:
         """
@@ -249,7 +281,14 @@ class Workspace(CodegateCommandSubcommand):
             "    - `workspace_name`\n\n"
             "- `activate`: Activate a workspace\n\n"
             "  - *args*:\n\n"
-            "    - `workspace_name`"
+            "    - `workspace_name`\n\n"
+            "- `remove`: Remove a workspace\n\n"
+            "  - *args*:\n\n"
+            "    - `workspace_name`\n\n"
+            "- `rename`: Rename a workspace\n\n"
+            "  - *args*:\n\n"
+            "    - `workspace_name`\n"
+            "    - `new_workspace_name`\n\n"
         )
 
 

--- a/src/codegate/workspaces/crud.py
+++ b/src/codegate/workspaces/crud.py
@@ -43,6 +43,32 @@ class WorkspaceCrud:
         workspace_created = await db_recorder.add_workspace(new_workspace_name)
         return workspace_created
 
+    async def rename_workspace(self, old_workspace_name: str, new_workspace_name: str) -> Workspace:
+        """
+        Rename a workspace
+
+        Args:
+            old_name (str): The old name of the workspace
+            new_name (str): The new name of the workspace
+        """
+        if new_workspace_name == "":
+            raise WorkspaceCrudError("Workspace name cannot be empty.")
+        if old_workspace_name == "":
+            raise WorkspaceCrudError("Workspace name cannot be empty.")
+        if old_workspace_name in DEFAULT_WORKSPACE_NAME:
+            raise WorkspaceCrudError("Cannot rename default workspace.")
+        if new_workspace_name in RESERVED_WORKSPACE_KEYWORDS:
+            raise WorkspaceCrudError(f"Workspace name {new_workspace_name} is reserved.")
+        if old_workspace_name == new_workspace_name:
+            raise WorkspaceCrudError("Old and new workspace names are the same.")
+        ws = await self._db_reader.get_workspace_by_name(old_workspace_name)
+        if not ws:
+            raise WorkspaceDoesNotExistError(f"Workspace {old_workspace_name} does not exist.")
+        db_recorder = DbRecorder()
+        new_ws = Workspace(id=ws.id, name=new_workspace_name, system_prompt=ws.system_prompt)
+        workspace_renamed = await db_recorder.update_workspace(new_ws)
+        return workspace_renamed
+
     async def get_workspaces(self) -> List[WorkspaceActive]:
         """
         Get all workspaces


### PR DESCRIPTION
This adds the CRUD API endpoints and pseudo-CLI subcommands to rename
workspaces. Note that `default` and `active` are reserved keywords and
cannot be used.

Closes: https://github.com/stacklok/codegate/issues/671
Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
