### PR TITLE
Toggle pragma on problematic migration

### DIFF
--- a/migrations/versions/2025_01_21_0820-4dec3e456c9e_add_on_delete_cascade.py
+++ b/migrations/versions/2025_01_21_0820-4dec3e456c9e_add_on_delete_cascade.py
@@ -18,6 +18,8 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    # Temporarily disable foreign key constraints
+    op.execute("PRAGMA foreign_keys=OFF;")
     # To add ON DELETE CASCADE to the foreign key constraint, we need to
     # rename the table, create a new table with the constraint, and copy
     # the data over.
@@ -97,6 +99,8 @@ def upgrade() -> None:
     op.execute("CREATE INDEX idx_prompts_workspace_id ON prompts (workspace_id);")
     op.execute("CREATE INDEX idx_sessions_workspace_id ON sessions (active_workspace_id);")
 
+    # Re-enable foreign key constraints
+    op.execute("PRAGMA foreign_keys=ON;")
 
 def downgrade() -> None:
     # Settings table


### PR DESCRIPTION
The migration setting the `ON DELETE CASCADE` was problematic with the
foreign key pragma. This toggles it so we can effectively do the
migration.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
