### PR TITLE
Fetch tags to get appropriate codegate version on dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ build: clean test
 	poetry build
 
 image-build:
+	@echo "Fetching tags to get right version number..."
+	@git fetch -t
+	@echo "Building container..."
 	DOCKER_BUILDKIT=1 $(CONTAINER_BUILD) \
 		-f Dockerfile \
 		--build-arg LATEST_RELEASE=$(shell curl -s "https://api.github.com/repos/stacklok/codegate-ui/releases/latest" | grep '"zipball_url":' | cut -d '"' -f 4) \


### PR DESCRIPTION
We need to rely on the tags to get the right version for codegate. This
fetches them before building the image locally. Note that this is only
for development.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
