### PR TITLE
Use `github.ref_name` for codegate version

### DIFF
--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -89,7 +89,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             LATEST_RELEASE=${{ env.LATEST_RELEASE }}
-            CODEGATE_VERSION=${{ steps.version-string.outputs.tag }}
+            CODEGATE_VERSION=${{ github.ref_name }}
       - name: Capture Image Digest
         id: image-digest
         run: |


### PR DESCRIPTION
The auto-generated tag was used to set the codegate version. This had
relevant information, but is not the version we actually wanted to set.
This instead uses github action context variables to set the version
appropriately.

For Releases (the trigger for the image publish job) the `ref_name`
refers to the tag the release had attached. This is what's used.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
