### PR TITLE
Fixes on migration ON_DELETE_CASCADE

### DIFF
--- a/migrations/versions/2025_01_21_0820-4dec3e456c9e_add_on_delete_cascade.py
+++ b/migrations/versions/2025_01_21_0820-4dec3e456c9e_add_on_delete_cascade.py
@@ -18,6 +18,9 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    # Begin transaction
+    op.execute("BEGIN TRANSACTION;")
+
     # To add ON DELETE CASCADE to the foreign key constraint, we need to
     # rename the table, create a new table with the constraint, and copy
     # the data over.
@@ -100,6 +103,9 @@ def upgrade() -> None:
     op.execute("CREATE INDEX idx_alerts_prompt_id ON alerts(prompt_id);")
     op.execute("CREATE INDEX idx_prompts_workspace_id ON prompts (workspace_id);")
     op.execute("CREATE INDEX idx_sessions_workspace_id ON sessions (active_workspace_id);")
+
+    # Finish transaction
+    op.execute("COMMIT;")
 
 
 def downgrade() -> None:

--- a/migrations/versions/2025_01_21_0820-4dec3e456c9e_add_on_delete_cascade.py
+++ b/migrations/versions/2025_01_21_0820-4dec3e456c9e_add_on_delete_cascade.py
@@ -18,6 +18,9 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    # Turn off foreign key constraints for this migration
+    op.execute("PRAGMA foreign_keys=off;")
+
     # Begin transaction
     op.execute("BEGIN TRANSACTION;")
 
@@ -106,6 +109,10 @@ def upgrade() -> None:
 
     # Finish transaction
     op.execute("COMMIT;")
+
+    # Turn on foreign key constraints after the migration. Just to be sure. This shouldn't
+    # be necessary, since it should be specified at the beginning of every connection, doesn't hurt.
+    op.execute("PRAGMA foreign_keys=on;")
 
 
 def downgrade() -> None:


### PR DESCRIPTION
We were under the believe that alembic migrations were running inside a transaction because of [Alembic's doc](https://alembic.sqlalchemy.org/en/latest/tutorial.html#the-migration-environment)
> At the very least, it contains instructions to configure and generate a SQLAlchemy engine, procure a connection from that engine along with a transaction, and then invoke the migration engine, using the connection as a source of database connectivity.

However, experience proved us wrong. This PR explicitly declares a transaction on the migration.

It also explicitly turns off FKs. The migration violates on purpose some constraints to move data between tables.