### PR TITLE
fix: Copilot provider not working on shortcut response

### DIFF
--- a/src/codegate/providers/copilot/pipeline.py
+++ b/src/codegate/providers/copilot/pipeline.py
@@ -126,6 +126,7 @@ class CopilotPipeline(ABC):
                     result, normalized_body.get("model", "gpt-4o-mini")
                 )
                 logger.info(f"Pipeline created shortcut response: {body}")
+                return body, result.context
             except Exception as e:
                 logger.error(f"Pipeline processing error: {e}")
                 return body, None


### PR DESCRIPTION
Closes: #723

We were not returning the response appropriately