### PR TITLE
Allow workspace operations to work without caring about the case

### DIFF
--- a/src/codegate/api/v1.py
+++ b/src/codegate/api/v1.py
@@ -27,7 +27,7 @@ async def list_workspaces() -> v1_models.ListWorkspacesResponse:
     """List all workspaces."""
     wslist = await wscrud.get_workspaces()
 
-    resp = v1_models.ListWorkspacesResponse.from_db_workspaces_active(wslist)
+    resp = v1_models.ListWorkspacesResponse.from_db_workspaces_with_sessioninfo(wslist)
 
     return resp
 

--- a/src/codegate/api/v1_models.py
+++ b/src/codegate/api/v1_models.py
@@ -23,19 +23,18 @@ class ListWorkspacesResponse(pydantic.BaseModel):
     workspaces: list[Workspace]
 
     @classmethod
-    def from_db_workspaces_active(
-        cls, db_workspaces: List[db_models.WorkspaceActive]
+    def from_db_workspaces_with_sessioninfo(
+        cls, db_workspaces: List[db_models.WorkspaceWithSessionInfo]
     ) -> "ListWorkspacesResponse":
         return cls(
             workspaces=[
-                Workspace(name=ws.name, is_active=ws.active_workspace_id is not None)
-                for ws in db_workspaces
+                Workspace(name=ws.name, is_active=ws.session_id is not None) for ws in db_workspaces
             ]
         )
 
     @classmethod
     def from_db_workspaces(
-        cls, db_workspaces: List[db_models.Workspace]
+        cls, db_workspaces: List[db_models.WorkspaceRow]
     ) -> "ListWorkspacesResponse":
         return cls(workspaces=[Workspace(name=ws.name, is_active=False) for ws in db_workspaces])
 

--- a/src/codegate/db/models.py
+++ b/src/codegate/db/models.py
@@ -30,7 +30,7 @@ class Prompt(BaseModel):
     workspace_id: Optional[str]
 
 
-WorskpaceNameStr = Annotated[
+WorkspaceNameStr = Annotated[
     str,
     StringConstraints(
         strip_whitespace=True, to_lower=True, pattern=r"^[a-zA-Z0-9_-]+$", strict=True
@@ -38,10 +38,24 @@ WorskpaceNameStr = Annotated[
 ]
 
 
-class Workspace(BaseModel):
+class WorkspaceRow(BaseModel):
+    """A workspace row entry.
+
+    Since our model currently includes instructions
+    in the same table, this is returned as a single
+    object.
+    """
+
     id: str
-    name: WorskpaceNameStr
+    name: WorkspaceNameStr
     custom_instructions: Optional[str]
+
+
+class GetWorkspaceByNameConditions(BaseModel):
+    name: WorkspaceNameStr
+
+    def get_conditions(self):
+        return {"name": self.name}
 
 
 class Session(BaseModel):
@@ -81,15 +95,24 @@ class GetPromptWithOutputsRow(BaseModel):
     output_timestamp: Optional[Any]
 
 
-class WorkspaceActive(BaseModel):
+class WorkspaceWithSessionInfo(BaseModel):
+    """Returns a workspace ID with an optional
+    session ID. If the session ID is None, then
+    the workspace is not active.
+    """
+
     id: str
-    name: str
-    active_workspace_id: Optional[str]
+    name: WorkspaceNameStr
+    session_id: Optional[str]
 
 
 class ActiveWorkspace(BaseModel):
+    """Returns a full active workspace object with the
+    with the session information.
+    """
+
     id: str
-    name: str
+    name: WorkspaceNameStr
     custom_instructions: Optional[str]
     session_id: str
     last_update: datetime.datetime

--- a/src/codegate/pipeline/cli/commands.py
+++ b/src/codegate/pipeline/cli/commands.py
@@ -168,7 +168,7 @@ class Workspace(CodegateCommandSubcommand):
         respond_str = ""
         for workspace in workspaces:
             respond_str += f"- {workspace.name}"
-            if workspace.active_workspace_id:
+            if workspace.session_id:
                 respond_str += " **(active)**"
             respond_str += "\n"
         return respond_str

--- a/tests/pipeline/workspace/test_workspace.py
+++ b/tests/pipeline/workspace/test_workspace.py
@@ -20,7 +20,7 @@ from codegate.pipeline.cli.commands import Workspace
                 # with 'name' attribute and 'session_id' set
                 WorkspaceWithSessionInfo(id="1", name="Workspace1", session_id="100")
             ],
-            "- Workspace1 **(active)**\n",
+            "- workspace1 **(active)**\n",
         ),
         # Case 3: Multiple workspaces, second one active
         (
@@ -28,7 +28,7 @@ from codegate.pipeline.cli.commands import Workspace
                 WorkspaceWithSessionInfo(id="1", name="Workspace1", session_id=None),
                 WorkspaceWithSessionInfo(id="2", name="Workspace2", session_id="200"),
             ],
-            "- Workspace1\n- Workspace2 **(active)**\n",
+            "- workspace1\n- workspace2 **(active)**\n",
         ),
     ],
 )

--- a/tests/pipeline/workspace/test_workspace.py
+++ b/tests/pipeline/workspace/test_workspace.py
@@ -2,8 +2,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from codegate.db.models import Workspace as WorkspaceModel
-from codegate.db.models import WorkspaceActive
+from codegate.db.models import WorkspaceRow as WorkspaceModel
+from codegate.db.models import WorkspaceWithSessionInfo
 from codegate.pipeline.cli.commands import Workspace
 
 
@@ -17,16 +17,16 @@ from codegate.pipeline.cli.commands import Workspace
         (
             [
                 # We'll make a MagicMock that simulates a workspace
-                # with 'name' attribute and 'active_workspace_id' set
-                WorkspaceActive(id="1", name="Workspace1", active_workspace_id="100")
+                # with 'name' attribute and 'session_id' set
+                WorkspaceWithSessionInfo(id="1", name="Workspace1", session_id="100")
             ],
             "- Workspace1 **(active)**\n",
         ),
         # Case 3: Multiple workspaces, second one active
         (
             [
-                WorkspaceActive(id="1", name="Workspace1", active_workspace_id=None),
-                WorkspaceActive(id="2", name="Workspace2", active_workspace_id="200"),
+                WorkspaceWithSessionInfo(id="1", name="Workspace1", session_id=None),
+                WorkspaceWithSessionInfo(id="2", name="Workspace2", session_id="200"),
             ],
             "- Workspace1\n- Workspace2 **(active)**\n",
         ),


### PR DESCRIPTION
Ultimately all operations will work regardless of the case. Though the
final storage format will be lowercase.

This also made changes to the db models to disambiguate the names from one another.

Closes: https://github.com/stacklok/codegate/issues/726
