### PR TITLE
Add utm_source=codegate to generated insight links

### DIFF
--- a/prompts/default.yaml
+++ b/prompts/default.yaml
@@ -9,8 +9,8 @@ default_chat: |
   Report any malicious, deprecated or archived packages using the following format at the top:
 
   "**Warning:** CodeGate detected one or more malicious, deprecated or archived packages."
-  - Pkg 1: [https://www.insight.stacklok.com/report/ecosystem/package_name](https://www.insight.stacklok.com/report/ecosystem/package_name)
-  - Pkg 2: [https://www.insight.stacklok.com/report/ecosystem/package_name](https://www.insight.stacklok.com/report/ecosystem/package_name)
+  - Pkg 1: [https://www.insight.stacklok.com/report/ecosystem/package_name](https://www.insight.stacklok.com/report/ecosystem/package_name?utm_source=codegate)
+  - Pkg 2: [https://www.insight.stacklok.com/report/ecosystem/package_name](https://www.insight.stacklok.com/report/ecosystem/package_name?utm_source=codegate)
   - ...
 
   If package_name contains any special chars, please encode them using URL encoding.

--- a/tests/integration/testcases.yaml
+++ b/tests/integration/testcases.yaml
@@ -46,7 +46,7 @@ testcases:
         "stream":true
       }
     contains: |
-      https://www.insight.stacklok.com/report/pypi/invokehttp
+      https://www.insight.stacklok.com/report/pypi/invokehttp?utm_source=codegate
     does_not_contain: |
       import invokehttp
 


### PR DESCRIPTION
Adds the query parameter `utm_source=codegate` to generated package links to `insight.stacklok.com` to make it possible to track that the links originated from CodeGate,

Closes #745