### PR TITLE
Fix Ollama URL from CLI help

### DIFF
--- a/src/codegate/cli.py
+++ b/src/codegate/cli.py
@@ -190,7 +190,7 @@ def show_prompts(prompts: Optional[Path]) -> None:
     "--ollama-url",
     type=str,
     default=None,
-    help="Ollama provider URL (default: http://localhost:11434/api)",
+    help="Ollama provider URL (default: http://localhost:11434/)",
 )
 @click.option(
     "--model-base-path",


### PR DESCRIPTION
The actual value does not include the `/api` resource. The "help" was
misleading.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
