### PR TITLE
Use type hints when getting config object

### DIFF
--- a/src/codegate/config.py
+++ b/src/codegate/config.py
@@ -360,5 +360,5 @@ class Config:
         return config
 
     @classmethod
-    def get_config(cls):
+    def get_config(cls) -> "Config":
         return cls.__config


### PR DESCRIPTION
The `get_config` class method now uses type hints which helps IDEs (and
me)

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
