### PR TITLE
Add mocked token-usage endpoints

### DIFF
--- a/src/codegate/api/v1.py
+++ b/src/codegate/api/v1.py
@@ -470,3 +470,25 @@ def version_check():
             "is_latest": None,
             "error": "An unexpected error occurred",
         }
+
+
+@v1.get(
+    "/workspaces/{workspace_name}/token-usage",
+    tags=["Workspaces", "Token Usage"],
+    generate_unique_id_function=uniq_name,
+)
+async def get_workspace_token_usage(workspace_name: str) -> v1_models.TokenUsage:
+    """Get the token usage of a workspace."""
+    # TODO: This is a dummy implementation. In the future, we should have a proper
+    # implementation that fetches the token usage from the database.
+    return v1_models.TokenUsage(
+        workspace_used_tokens=50,
+        tokens_by_model=[
+            v1_models.TokenUsageByModel(
+                provider_type="openai", model="gpt-4o-mini", used_tokens=20
+            ),
+            v1_models.TokenUsageByModel(
+                provider_type="anthropic", model="claude-3-5-sonnet-20241022", used_tokens=30
+            ),
+        ],
+    )

--- a/src/codegate/api/v1_models.py
+++ b/src/codegate/api/v1_models.py
@@ -124,6 +124,7 @@ class Conversation(pydantic.BaseModel):
     type: QuestionType
     chat_id: str
     conversation_timestamp: datetime.datetime
+    token_usage: Optional[int]
 
 
 class AlertConversation(pydantic.BaseModel):
@@ -218,3 +219,24 @@ class MuxRule(pydantic.BaseModel):
     # The actual matcher to use. Note that
     # this depends on the matcher type.
     matcher: Optional[str]
+
+
+class TokenUsageByModel(pydantic.BaseModel):
+    """
+    Represents the tokens used by a model.
+    """
+
+    provider_type: ProviderType
+    model: str
+    used_tokens: int
+
+
+class TokenUsage(pydantic.BaseModel):
+    """
+    Represents the tokens used by a workspace. Includes the information of the tokens used
+    by model.
+    `used_tokens` are the total tokens used in the `tokens_by_model` list.
+    """
+
+    tokens_by_model: List[TokenUsageByModel]
+    workspace_used_tokens: int

--- a/src/codegate/api/v1_processing.py
+++ b/src/codegate/api/v1_processing.py
@@ -331,6 +331,7 @@ async def match_conversations(
                 type=first_partial_qa.partial_questions.type,
                 chat_id=first_partial_qa.partial_questions.message_id,
                 conversation_timestamp=first_partial_qa.partial_questions.timestamp,
+                token_usage=None,
             )
             for qa in questions_answers:
                 map_q_id_to_conversation[qa.question.message_id] = conversation


### PR DESCRIPTION
For the moment mocked the token usage endpoints. This would be the request with most of the information
```bash
curl 'http://localhost:8989/api/v1/workspaces/default/token-usage'
```

It will bring the total tokens used in the workspace. Additionally it will have a breakdown of how many tokens were used by each model in the workspace