### PR TITLE
Kick off provider endpoint CRUD structure and registration

### DIFF
--- a/src/codegate/cli.py
+++ b/src/codegate/cli.py
@@ -17,6 +17,7 @@ from codegate.config import Config, ConfigurationError
 from codegate.db.connection import init_db_sync, init_session_if_not_exists
 from codegate.pipeline.factory import PipelineFactory
 from codegate.pipeline.secrets.manager import SecretsManager
+from codegate.providers import crud as provendcrud
 from codegate.providers.copilot.provider import CopilotProvider
 from codegate.server import init_app
 from codegate.storage.utils import restore_storage_backup
@@ -337,6 +338,9 @@ def serve(  # noqa: C901
         # Set up event loop
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
+
+        registry = app.provider_registry
+        loop.run_until_complete(provendcrud.initialize_provider_endpoints(registry))
 
         # Run the server
         try:

--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -21,6 +21,9 @@ from codegate.db.models import (
     GetWorkspaceByNameConditions,
     Output,
     Prompt,
+    ProviderAuthMaterial,
+    ProviderEndpoint,
+    ProviderModel,
     Session,
     WorkspaceRow,
     WorkspaceWithSessionInfo,
@@ -368,6 +371,72 @@ class DbRecorder(DbCodeGate):
         )
         return recovered_workspace
 
+    async def add_provider_endpoint(self, provider: ProviderEndpoint) -> ProviderEndpoint:
+        sql = text(
+            """
+            INSERT INTO provider_endpoints (
+                id, name, description, provider_type, endpoint, auth_type, auth_blob
+            )
+            VALUES (:id, :name, :description, :provider_type, :endpoint, :auth_type, "")
+            RETURNING *
+            """
+        )
+        added_provider = await self._execute_update_pydantic_model(provider, sql, should_raise=True)
+        return added_provider
+
+    async def update_provider_endpoint(self, provider: ProviderEndpoint) -> ProviderEndpoint:
+        sql = text(
+            """
+            UPDATE provider_endpoints
+            SET name = :name, description = :description, provider_type = :provider_type,
+            endpoint = :endpoint, auth_type = :auth_type
+            WHERE id = :id
+            RETURNING *
+            """
+        )
+        updated_provider = await self._execute_update_pydantic_model(
+            provider, sql, should_raise=True
+        )
+        return updated_provider
+
+    async def delete_provider_endpoint(
+        self,
+        provider: ProviderEndpoint,
+    ) -> Optional[ProviderEndpoint]:
+        sql = text(
+            """
+            DELETE FROM provider_endpoints
+            WHERE id = :id
+            RETURNING *
+            """
+        )
+        deleted_provider = await self._execute_update_pydantic_model(
+            provider, sql, should_raise=True
+        )
+        return deleted_provider
+
+    async def push_provider_auth_material(self, auth_material: ProviderAuthMaterial):
+        sql = text(
+            """
+            UPDATE provider_endpoints
+            SET auth_type = :auth_type, auth_blob = :auth_blob
+            WHERE id = :provider_endpoint_id
+            """
+        )
+        _ = await self._execute_update_pydantic_model(auth_material, sql, should_raise=True)
+        return
+
+    async def add_provider_model(self, model: ProviderModel) -> ProviderModel:
+        sql = text(
+            """
+            INSERT INTO provider_models (provider_endpoint_id, name)
+            VALUES (:provider_endpoint_id, :name)
+            RETURNING *
+            """
+        )
+        added_model = await self._execute_update_pydantic_model(model, sql, should_raise=True)
+        return added_model
+
 
 class DbReader(DbCodeGate):
 
@@ -536,6 +605,69 @@ class DbReader(DbCodeGate):
         )
         active_workspace = await self._execute_select_pydantic_model(ActiveWorkspace, sql)
         return active_workspace[0] if active_workspace else None
+
+    async def get_provider_endpoint_by_name(self, provider_name: str) -> Optional[ProviderEndpoint]:
+        sql = text(
+            """
+            SELECT id, name, description, provider_type, endpoint, auth_type, created_at, updated_at
+            FROM provider_endpoints
+            WHERE name = :name
+            """
+        )
+        conditions = {"name": provider_name}
+        provider = await self._exec_select_conditions_to_pydantic(
+            ProviderEndpoint, sql, conditions, should_raise=True
+        )
+        return provider[0] if provider else None
+
+    async def get_provider_endpoint_by_id(self, provider_id: str) -> Optional[ProviderEndpoint]:
+        sql = text(
+            """
+            SELECT id, name, description, provider_type, endpoint, auth_type, created_at, updated_at
+            FROM provider_endpoints
+            WHERE id = :id
+            """
+        )
+        conditions = {"id": provider_id}
+        provider = await self._exec_select_conditions_to_pydantic(
+            ProviderEndpoint, sql, conditions, should_raise=True
+        )
+        return provider[0] if provider else None
+
+    async def get_provider_endpoints(self) -> List[ProviderEndpoint]:
+        sql = text(
+            """
+            SELECT id, name, description, provider_type, endpoint, auth_type, created_at, updated_at
+            FROM provider_endpoints
+            """
+        )
+        providers = await self._execute_select_pydantic_model(ProviderEndpoint, sql)
+        return providers
+
+    async def get_provider_models_by_provider_id(self, provider_id: str) -> List[ProviderModel]:
+        sql = text(
+            """
+            SELECT provider_endpoint_id, name
+            FROM provider_models
+            WHERE provider_endpoint_id = :provider_endpoint_id
+            """
+        )
+        conditions = {"provider_endpoint_id": provider_id}
+        models = await self._exec_select_conditions_to_pydantic(
+            ProviderModel, sql, conditions, should_raise=True
+        )
+        return models
+
+    async def get_all_provider_models(self) -> List[ProviderModel]:
+        sql = text(
+            """
+            SELECT pm.provider_endpoint_id, pm.name, pe.name as provider_endpoint_name
+            FROM provider_models pm
+            INNER JOIN provider_endpoints pe ON pm.provider_endpoint_id = pe.id
+            """
+        )
+        models = await self._execute_select_pydantic_model(ProviderModel, sql)
+        return models
 
 
 def init_db_sync(db_path: Optional[str] = None):

--- a/src/codegate/db/models.py
+++ b/src/codegate/db/models.py
@@ -99,3 +99,24 @@ class ActiveWorkspace(BaseModel):
     custom_instructions: Optional[str]
     session_id: str
     last_update: datetime.datetime
+
+
+class ProviderEndpoint(BaseModel):
+    id: str
+    name: str
+    description: str
+    provider_type: str
+    endpoint: str
+    auth_type: str
+
+
+class ProviderAuthMaterial(BaseModel):
+    provider_endpoint_id: str
+    auth_type: str
+    auth_blob: str
+
+
+class ProviderModel(BaseModel):
+    provider_endpoint_id: str
+    provider_endpoint_name: Optional[str] = None
+    name: str

--- a/src/codegate/providers/base.py
+++ b/src/codegate/providers/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, AsyncIterator, Callable, Dict, Optional, Union
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Union
 
 import structlog
 from fastapi import APIRouter, Request
@@ -52,6 +52,10 @@ class BaseProvider(ABC):
 
     @abstractmethod
     def _setup_routes(self) -> None:
+        pass
+
+    @abstractmethod
+    def models(self) -> List[str]:
         pass
 
     @property

--- a/src/codegate/providers/crud/__init__.py
+++ b/src/codegate/providers/crud/__init__.py
@@ -1,0 +1,3 @@
+from .crud import ProviderCrud, ProviderNotFoundError, initialize_provider_endpoints
+
+__all__ = ["ProviderCrud", "initialize_provider_endpoints", "ProviderNotFoundError"]

--- a/src/codegate/providers/crud/crud.py
+++ b/src/codegate/providers/crud/crud.py
@@ -1,0 +1,229 @@
+import asyncio
+from typing import List, Optional
+from urllib.parse import urlparse
+from uuid import UUID, uuid4
+
+import structlog
+from pydantic import ValidationError
+
+from codegate.api import v1_models as apimodelsv1
+from codegate.config import Config
+from codegate.db import models as dbmodels
+from codegate.db.connection import DbReader, DbRecorder
+from codegate.providers.base import BaseProvider
+from codegate.providers.registry import ProviderRegistry
+
+logger = structlog.get_logger("codegate")
+
+
+class ProviderNotFoundError(Exception):
+    pass
+
+
+class ProviderCrud:
+    """The CRUD operations for the provider endpoint references within
+    Codegate.
+
+    This is meant to handle all the transformations in between the
+    database and the API, as well as other sources of information. All
+    operations should result in the API models being returned.
+    """
+
+    def __init__(self):
+        self._db_reader = DbReader()
+        self._db_writer = DbRecorder()
+
+    async def list_endpoints(self) -> List[apimodelsv1.ProviderEndpoint]:
+        """List all the endpoints."""
+
+        outendpoints = []
+        dbendpoints = await self._db_reader.get_provider_endpoints()
+        for dbendpoint in dbendpoints:
+            outendpoints.append(apimodelsv1.ProviderEndpoint.from_db_model(dbendpoint))
+
+        return outendpoints
+
+    async def get_endpoint_by_id(self, id: UUID) -> Optional[apimodelsv1.ProviderEndpoint]:
+        """Get an endpoint by ID."""
+
+        dbendpoint = await self._db_reader.get_provider_endpoint_by_id(str(id))
+        if dbendpoint is None:
+            return None
+
+        return apimodelsv1.ProviderEndpoint.from_db_model(dbendpoint)
+
+    async def get_endpoint_by_name(self, name: str) -> Optional[apimodelsv1.ProviderEndpoint]:
+        """Get an endpoint by name."""
+
+        dbendpoint = await self._db_reader.get_provider_endpoint_by_name(name)
+        if dbendpoint is None:
+            return None
+
+        return apimodelsv1.ProviderEndpoint.from_db_model(dbendpoint)
+
+    async def add_endpoint(
+        self, endpoint: apimodelsv1.ProviderEndpoint
+    ) -> apimodelsv1.ProviderEndpoint:
+        """Add an endpoint."""
+        dbend = endpoint.to_db_model()
+
+        # We override the ID here, as we want to generate it.
+        dbend.id = str(uuid4())
+
+        dbendpoint = await self._db_writer.add_provider_endpoint()
+        return apimodelsv1.ProviderEndpoint.from_db_model(dbendpoint)
+
+    async def update_endpoint(
+        self, endpoint: apimodelsv1.ProviderEndpoint
+    ) -> apimodelsv1.ProviderEndpoint:
+        """Update an endpoint."""
+
+        dbendpoint = await self._db_writer.update_provider_endpoint(endpoint.to_db_model())
+        return apimodelsv1.ProviderEndpoint.from_db_model(dbendpoint)
+
+    async def delete_endpoint(self, provider_id: UUID):
+        """Delete an endpoint."""
+
+        dbendpoint = await self._db_reader.get_provider_endpoint_by_id(str(provider_id))
+        if dbendpoint is None:
+            raise ProviderNotFoundError("Provider not found")
+
+        await self._db_writer.delete_provider_endpoint(dbendpoint)
+
+    async def models_by_provider(self, provider_id: UUID) -> List[apimodelsv1.ModelByProvider]:
+        """Get the models by provider."""
+
+        # First we try to get the provider
+        dbendpoint = await self._db_reader.get_provider_endpoint_by_id(str(provider_id))
+        if dbendpoint is None:
+            raise ProviderNotFoundError("Provider not found")
+
+        outmodels = []
+        dbmodels = await self._db_reader.get_provider_models_by_provider_id(str(provider_id))
+        for dbmodel in dbmodels:
+            outmodels.append(
+                apimodelsv1.ModelByProvider(
+                    name=dbmodel.name,
+                    provider_id=dbmodel.provider_endpoint_id,
+                    provider_name=dbendpoint.name,
+                )
+            )
+
+        return outmodels
+
+    async def get_all_models(self) -> List[apimodelsv1.ModelByProvider]:
+        """Get all the models."""
+
+        outmodels = []
+        dbmodels = await self._db_reader.get_all_provider_models()
+        for dbmodel in dbmodels:
+            ename = dbmodel.provider_endpoint_name if dbmodel.provider_endpoint_name else ""
+            outmodels.append(
+                apimodelsv1.ModelByProvider(
+                    name=dbmodel.name,
+                    provider_id=dbmodel.provider_endpoint_id,
+                    provider_name=ename,
+                )
+            )
+
+        return outmodels
+
+
+async def initialize_provider_endpoints(preg: ProviderRegistry):
+    db_writer = DbRecorder()
+    db_reader = DbReader()
+    config = Config.get_config()
+    if config is None:
+        provided_urls = {}
+    else:
+        provided_urls = config.provider_urls
+
+    for provider_name, provider_url in provided_urls.items():
+        provend = __provider_endpoint_from_cfg(provider_name, provider_url)
+        if provend is None:
+            continue
+
+        # Check if the provider is already in the db
+        dbprovend = await db_reader.get_provider_endpoint_by_name(provend.name)
+        if dbprovend is not None:
+            logger.debug(
+                "Provider already in DB. Not re-adding.",
+                provider=provend.name,
+                endpoint=provend.endpoint,
+            )
+            continue
+
+        pimpl = provend.get_from_registry(preg)
+        await try_initialize_provider_endpoints(provend, pimpl, db_writer)
+
+
+async def try_initialize_provider_endpoints(
+    provend: apimodelsv1.ProviderEndpoint,
+    pimpl: BaseProvider,
+    db_writer: DbRecorder,
+):
+    try:
+        models = pimpl.models()
+    except Exception as err:
+        logger.debug(
+            "Unable to get models from provider",
+            provider=provend.name,
+            err=str(err),
+        )
+        return
+
+    logger.info(
+        "initializing provider to DB",
+        provider=provend.name,
+        endpoint=provend.endpoint,
+        models=models,
+    )
+    # We only try to add the provider if we have models
+    await db_writer.add_provider_endpoint(provend.to_db_model())
+
+    tasks = set()
+    for model in models:
+        tasks.add(
+            db_writer.add_provider_model(
+                dbmodels.ProviderModel(
+                    provider_endpoint_id=provend.id,
+                    name=model,
+                )
+            )
+        )
+
+    await asyncio.gather(*tasks)
+
+
+def __provider_endpoint_from_cfg(
+    provider_name: str, provider_url: str
+) -> Optional[apimodelsv1.ProviderEndpoint]:
+    """Create a provider endpoint from the config entry."""
+
+    try:
+        _ = urlparse(provider_url)
+    except Exception:
+        logger.warning(
+            "Invalid provider URL", provider_name=provider_name, provider_url=provider_url
+        )
+        return None
+
+    try:
+        return apimodelsv1.ProviderEndpoint(
+            id=str(uuid4()),
+            name=provider_name,
+            endpoint=provider_url,
+            description=("Endpoint for the {} provided via the CodeGate configuration.").format(
+                provider_name
+            ),
+            provider_type=provider_name,
+            auth_type=apimodelsv1.ProviderAuthType.passthrough,
+        )
+    except ValidationError as err:
+        logger.warning(
+            "Invalid provider name",
+            provider_name=provider_name,
+            provider_url=provider_url,
+            err=str(err),
+        )
+        return None

--- a/src/codegate/providers/llamacpp/provider.py
+++ b/src/codegate/providers/llamacpp/provider.py
@@ -1,5 +1,6 @@
 import json
 
+import httpx
 import structlog
 from fastapi import HTTPException, Request
 
@@ -25,6 +26,13 @@ class LlamaCppProvider(BaseProvider):
     @property
     def provider_route_name(self) -> str:
         return "llamacpp"
+
+    def models(self):
+        # HACK: This is using OpenAI's /v1/models endpoint to get the list of models
+        resp = httpx.get(f"{self.base_url}/v1/models")
+        jsonresp = resp.json()
+
+        return [model["id"] for model in jsonresp.get("data", [])]
 
     def _setup_routes(self):
         """

--- a/src/codegate/providers/ollama/provider.py
+++ b/src/codegate/providers/ollama/provider.py
@@ -34,6 +34,12 @@ class OllamaProvider(BaseProvider):
     def provider_route_name(self) -> str:
         return "ollama"
 
+    def models(self):
+        resp = httpx.get(f"{self.base_url}/api/tags")
+        jsonresp = resp.json()
+
+        return [model["name"] for model in jsonresp.get("models", [])]
+
     def _setup_routes(self):
         """
         Sets up Ollama API routes.

--- a/src/codegate/providers/openai/provider.py
+++ b/src/codegate/providers/openai/provider.py
@@ -1,5 +1,7 @@
 import json
+from typing import List
 
+import httpx
 import structlog
 from fastapi import Header, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -32,6 +34,13 @@ class OpenAIProvider(BaseProvider):
     @property
     def provider_route_name(self) -> str:
         return "openai"
+
+    def models(self) -> List[str]:
+        # NOTE: This won't work since we need an API Key being set.
+        resp = httpx.get(f"{self.lm_studio_url}/v1/models")
+        jsonresp = resp.json()
+
+        return [model["id"] for model in jsonresp.get("data", [])]
 
     def _setup_routes(self):
         """

--- a/src/codegate/providers/vllm/provider.py
+++ b/src/codegate/providers/vllm/provider.py
@@ -31,6 +31,12 @@ class VLLMProvider(BaseProvider):
     def provider_route_name(self) -> str:
         return "vllm"
 
+    def models(self):
+        resp = httpx.get(f"{self.base_url}/v1/models")
+        jsonresp = resp.json()
+
+        return [model["id"] for model in jsonresp.get("data", [])]
+
     def _setup_routes(self):
         """
         Sets up the /chat/completions route for the provider as expected by the

--- a/src/codegate/server.py
+++ b/src/codegate/server.py
@@ -30,9 +30,16 @@ async def custom_error_handler(request, exc: Exception):
     return JSONResponse({"error": str(exc)}, status_code=500)
 
 
-def init_app(pipeline_factory: PipelineFactory) -> FastAPI:
+class CodeGateServer(FastAPI):
+    provider_registry: ProviderRegistry = None
+
+    def set_provider_registry(self, registry: ProviderRegistry):
+        self.provider_registry = registry
+
+
+def init_app(pipeline_factory: PipelineFactory) -> CodeGateServer:
     """Create the FastAPI application."""
-    app = FastAPI(
+    app = CodeGateServer(
         title="CodeGate",
         description=__description__,
         version=__version__,
@@ -58,6 +65,7 @@ def init_app(pipeline_factory: PipelineFactory) -> FastAPI:
 
     # Create provider registry
     registry = ProviderRegistry(app)
+    app.set_provider_registry(registry)
 
     # Register all known providers
     registry.add_provider(

--- a/tests/providers/test_registry.py
+++ b/tests/providers/test_registry.py
@@ -93,6 +93,9 @@ class MockProvider(BaseProvider):
     def provider_route_name(self) -> str:
         return "mock_provider"
 
+    def models(self):
+        return []
+
     def _setup_routes(self) -> None:
         @self.router.get(f"/{self.provider_route_name}/test")
         def test_route():

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -19,6 +19,9 @@ class MockProvider(BaseProvider):
             mocked_factory,
         )
 
+    def models(self):
+        return []
+
     def _setup_routes(self) -> None:
         pass
 


### PR DESCRIPTION
This structure will handle all the database operations and turn that
into the right models.

Note that for provider endpoints we already have a way of setting these
via configuration, so this is taken into account to output some sample
objects that users can leverage.

Each provider will need to implement a `models` function which allows us
to auto-discover models for a provider.

Closes: #784
Closes: #785 

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
