### PR TITLE
Enable the integration tests for vllm

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -189,7 +189,7 @@ jobs:
           docker build -f Dockerfile.cpu -t vllm-cpu-env --shm-size=4g .
           docker run -d  --name vllm \
              --network="host" \
-             vllm-cpu-env --model Qwen/Qwen2.5-Coder-1.5B-Instruct
+             vllm-cpu-env --model Qwen/Qwen2.5-Coder-3B-Instruct
 
       - name: Verify the vllm container is running
         run: |
@@ -205,7 +205,7 @@ jobs:
 
           echo -e "\nVerify the completions endpoint works\n"
           curl http://localhost:8000/v1/completions -H "Content-Type: application/json"   -d '{
-              "model": "Qwen/Qwen2.5-Coder-1.5B-Instruct",
+              "model": "Qwen/Qwen2.5-Coder-3B-Instruct",
               "prompt": ["How to make pizza"],
               "max_tokens": 100,
               "temperature": 0
@@ -215,7 +215,7 @@ jobs:
           curl -X POST http://localhost:8000/v1/chat/completions \
               -H "Content-Type: application/json" \
               -d '{
-                "model": "Qwen/Qwen2.5-Coder-1.5B-Instruct",
+                "model": "Qwen/Qwen2.5-Coder-3B-Instruct",
                 "messages": [
                   {"role": "system", "content": "You are a coding assistant."},
                   {"role": "user", "content": "Hello"}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -189,7 +189,7 @@ jobs:
           docker build -f Dockerfile.cpu -t vllm-cpu-env --shm-size=4g .
           docker run -d  --name vllm \
              --network="host" \
-             vllm-cpu-env --model Qwen/Qwen2.5-Coder-3B-Instruct
+             vllm-cpu-env --model Qwen/Qwen2.5-Coder-0.5B-Instruct
 
       - name: Verify the vllm container is running
         run: |
@@ -205,7 +205,7 @@ jobs:
 
           echo -e "\nVerify the completions endpoint works\n"
           curl http://localhost:8000/v1/completions -H "Content-Type: application/json"   -d '{
-              "model": "Qwen/Qwen2.5-Coder-3B-Instruct",
+              "model": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
               "prompt": ["How to make pizza"],
               "max_tokens": 100,
               "temperature": 0
@@ -215,7 +215,7 @@ jobs:
           curl -X POST http://localhost:8000/v1/chat/completions \
               -H "Content-Type: application/json" \
               -d '{
-                "model": "Qwen/Qwen2.5-Coder-3B-Instruct",
+                "model": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
                 "messages": [
                   {"role": "system", "content": "You are a coding assistant."},
                   {"role": "user", "content": "Hello"}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -62,6 +62,7 @@ jobs:
             -v "$(pwd)"/codegate_volume:/app/codegate_volume \
             -e CODEGATE_APP_LOG_LEVEL=DEBUG \
             -e CODEGATE_OLLAMA_URL=http://localhost:11434 \
+            -e CODEGATE_VLLM_URL=http://localhost:8000 \
             --restart unless-stopped $DOCKER_IMAGE
 
           # Confirm the container started
@@ -181,7 +182,60 @@ jobs:
         run: |
           docker logs ollama
 
-      - name: Print the container logs (useful for debugging)
+      - name: Build and run the vllm container
+        run: |
+          git clone https://github.com/vllm-project/vllm.git
+          cd vllm
+          docker build -f Dockerfile.cpu -t vllm-cpu-env --shm-size=4g .
+          docker run -d  --name vllm \
+             --network="host" \
+             vllm-cpu-env --model Qwen/Qwen2.5-Coder-1.5B-Instruct
+
+      - name: Verify the vllm container is running
+        run: |
+          echo -e "\nVerify the vllm container is serving\n"
+          docker ps -f name=vllm
+
+          echo "Loop until the endpoint responds successfully"
+          while ! curl --silent --fail --get "http://localhost:8000/ping" >/dev/null; do
+            echo "Ping not available yet. Retrying in 2 seconds..."
+            sleep 2
+          done
+          echo -e "\nPing is now available!\n"
+
+          echo -e "\nVerify the completions endpoint works\n"
+          curl http://localhost:8000/v1/completions -H "Content-Type: application/json"   -d '{
+              "model": "Qwen/Qwen2.5-Coder-1.5B-Instruct",
+              "prompt": ["How to make pizza"],
+              "max_tokens": 100,
+              "temperature": 0
+            }'
+
+          echo -e "\nVerify the chat/completions endpoint works\n"
+          curl -X POST http://localhost:8000/v1/chat/completions \
+              -H "Content-Type: application/json" \
+              -d '{
+                "model": "Qwen/Qwen2.5-Coder-1.5B-Instruct",
+                "messages": [
+                  {"role": "system", "content": "You are a coding assistant."},
+                  {"role": "user", "content": "Hello"}
+                ],
+                "temperature": 0,
+                "max_tokens": 4096,
+                "extra_body": {}
+              }'
+
+          # Print a new line and then the message in a single echo
+          echo -e "\nPrint the vllm container logs\n"
+          docker logs vllm
+
+      - name: Run integration tests - vllm
+        env:
+          CODEGATE_PROVIDERS: "vllm"
+        run: |
+          poetry run python tests/integration/integration_tests.py
+
+      - name: Print the CodeGate container logs (useful for debugging)
         if: always()
         run: |
           docker logs $CONTAINER_NAME
@@ -194,3 +248,8 @@ jobs:
           echo "DB contents:"
           ls -la codegate_volume/db
           docker exec $CONTAINER_NAME ls -la /app/codegate_volume/db
+
+      - name: Print the vllm container logs (useful for debugging)
+        if: always()
+        run: |
+          docker logs vllm

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -189,7 +189,7 @@ jobs:
           docker build -f Dockerfile.cpu -t vllm-cpu-env --shm-size=4g .
           docker run -d  --name vllm \
              --network="host" \
-             vllm-cpu-env --model Qwen/Qwen2.5-Coder-0.5B-Instruct
+             vllm-cpu-env --model Qwen/Qwen2.5-Coder-0.5B
 
       - name: Verify the vllm container is running
         run: |
@@ -205,7 +205,7 @@ jobs:
 
           echo -e "\nVerify the completions endpoint works\n"
           curl http://localhost:8000/v1/completions -H "Content-Type: application/json"   -d '{
-              "model": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
+              "model": "Qwen/Qwen2.5-Coder-0.5B",
               "prompt": ["How to make pizza"],
               "max_tokens": 100,
               "temperature": 0
@@ -215,7 +215,7 @@ jobs:
           curl -X POST http://localhost:8000/v1/chat/completions \
               -H "Content-Type: application/json" \
               -d '{
-                "model": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
+                "model": "Qwen/Qwen2.5-Coder-0.5B",
                 "messages": [
                   {"role": "system", "content": "You are a coding assistant."},
                   {"role": "user", "content": "Hello"}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -189,7 +189,7 @@ jobs:
           docker build -f Dockerfile.cpu -t vllm-cpu-env --shm-size=4g .
           docker run -d  --name vllm \
              --network="host" \
-             vllm-cpu-env --model Qwen/Qwen2.5-Coder-0.5B
+             vllm-cpu-env --model Qwen/Qwen2.5-Coder-0.5B-Instruct
 
       - name: Verify the vllm container is running
         run: |
@@ -205,7 +205,7 @@ jobs:
 
           echo -e "\nVerify the completions endpoint works\n"
           curl http://localhost:8000/v1/completions -H "Content-Type: application/json"   -d '{
-              "model": "Qwen/Qwen2.5-Coder-0.5B",
+              "model": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
               "prompt": ["How to make pizza"],
               "max_tokens": 100,
               "temperature": 0
@@ -215,7 +215,7 @@ jobs:
           curl -X POST http://localhost:8000/v1/chat/completions \
               -H "Content-Type: application/json" \
               -d '{
-                "model": "Qwen/Qwen2.5-Coder-0.5B",
+                "model": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
                 "messages": [
                   {"role": "system", "content": "You are a coding assistant."},
                   {"role": "user", "content": "Hello"}

--- a/src/codegate/providers/vllm/adapter.py
+++ b/src/codegate/providers/vllm/adapter.py
@@ -102,6 +102,7 @@ class VLLMInputNormalizer(ModelInputNormalizer):
         content = input_chat_request["messages"][0]["content"]
         if isinstance(content, str) and "<|im_start|>" in content:
             return True
+        return False
 
     def normalize(self, data: Dict) -> ChatCompletionRequest:
         """
@@ -116,12 +117,6 @@ class VLLMInputNormalizer(ModelInputNormalizer):
             model_name = normalized_data["model"]
             if not model_name.startswith("hosted_vllm/"):
                 normalized_data["model"] = f"hosted_vllm/{model_name}"
-
-        # Ensure the base_url ends with /v1 if provided
-        if "base_url" in normalized_data:
-            base_url = normalized_data["base_url"].rstrip("/")
-            if not base_url.endswith("/v1"):
-                normalized_data["base_url"] = f"{base_url}/v1"
 
         ret_data = normalized_data
         if self._has_chat_ml_format(normalized_data):

--- a/tests/integration/testcases.yaml
+++ b/tests/integration/testcases.yaml
@@ -1,6 +1,6 @@
 headers:
   vllm:
-    Authorization: Bearer ENV_VLLM_KEY
+    Content-Type: application/json
   openai:
     Authorization: Bearer ENV_OPENAI_KEY
   ollama:
@@ -161,12 +161,12 @@ testcases:
               "role":"user"
             }
         ],
-        "model":"Qwen/Qwen2.5-Coder-14B-Instruct",
+        "model":"Qwen/Qwen2.5-Coder-1.5B-Instruct",
         "stream":true,
         "temperature":0
       }
     likes: |
-      Hello! How can I assist you today? If you have any questions about software security, package analysis, or need guidance on secure coding practices, feel free to ask.
+      Hello! How can I assist you today?
 
   vllm_fim:
     name: VLLM FIM
@@ -174,7 +174,7 @@ testcases:
     url: http://127.0.0.1:8989/vllm/completions
     data: |
       {
-        "model": "Qwen/Qwen2.5-Coder-14B",
+        "model": "Qwen/Qwen2.5-Coder-1.5B-Instruct",
         "max_tokens": 4096,
         "temperature": 0,
         "stream": true,

--- a/tests/integration/testcases.yaml
+++ b/tests/integration/testcases.yaml
@@ -161,7 +161,7 @@ testcases:
               "role":"user"
             }
         ],
-        "model":"Qwen/Qwen2.5-Coder-0.5B-Instruct",
+        "model":"Qwen/Qwen2.5-Coder-0.5B",
         "stream":true,
         "temperature":0
       }
@@ -174,7 +174,7 @@ testcases:
     url: http://127.0.0.1:8989/vllm/completions
     data: |
       {
-        "model": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
+        "model": "Qwen/Qwen2.5-Coder-0.5B",
         "max_tokens": 4096,
         "temperature": 0,
         "stream": true,

--- a/tests/integration/testcases.yaml
+++ b/tests/integration/testcases.yaml
@@ -161,7 +161,7 @@ testcases:
               "role":"user"
             }
         ],
-        "model":"Qwen/Qwen2.5-Coder-1.5B-Instruct",
+        "model":"Qwen/Qwen2.5-Coder-3B-Instruct",
         "stream":true,
         "temperature":0
       }
@@ -174,7 +174,7 @@ testcases:
     url: http://127.0.0.1:8989/vllm/completions
     data: |
       {
-        "model": "Qwen/Qwen2.5-Coder-1.5B-Instruct",
+        "model": "Qwen/Qwen2.5-Coder-3B-Instruct",
         "max_tokens": 4096,
         "temperature": 0,
         "stream": true,

--- a/tests/integration/testcases.yaml
+++ b/tests/integration/testcases.yaml
@@ -178,7 +178,20 @@ testcases:
         "max_tokens": 4096,
         "temperature": 0,
         "stream": true,
-        "stop": ["<|endoftext|>", "<|fim_prefix|>", "<|fim_middle|>", "<|fim_suffix|>", "<|fim_pad|>", "<|repo_name|>", "<|file_sep|>", "<|im_start|>", "<|im_end|>", "/src/", "#- coding: utf-8", "```"],
+        "stop": [
+          "<|endoftext|>",
+          "<|fim_prefix|>",
+          "<|fim_middle|>",
+          "<|fim_suffix|>",
+          "<|fim_pad|>",
+          "<|repo_name|>",
+          "<|file_sep|>",
+          "<|im_start|>",
+          "<|im_end|>",
+          "/src/",
+          "#- coding: utf-8",
+          "```"
+        ],
         "prompt":"<|fim_prefix|>\n# codegate/test.py\nimport invokehttp\nimport requests\n\nkey = \"mysecret-key\"\n\ndef call_api():\n    <|fim_suffix|>\n\n\ndata = {'key1': 'test1', 'key2': 'test2'}\nresponse = call_api('http://localhost:8080', method='post', data='data')\n<|fim_middle|>"
       }
     likes: |

--- a/tests/integration/testcases.yaml
+++ b/tests/integration/testcases.yaml
@@ -195,19 +195,14 @@ testcases:
         "prompt":"<|fim_prefix|>\n# codegate/test.py\nimport invokehttp\nimport requests\n\nkey = \"mysecret-key\"\n\ndef call_api():\n    <|fim_suffix|>\n\n\ndata = {'key1': 'test1', 'key2': 'test2'}\nresponse = call_api('http://localhost:8080', method='post', data='data')\n<|fim_middle|>"
       }
     likes: |
-      # Create an instance of the InvokeHTTP class
-      invoke = invokehttp.InvokeHTTP(key)
+      return response.json()
 
-      # Call the API using the invoke_http method
-      response = invoke.invoke_http(url, method='get', data=data)
+      def test_call_api():
+          response = call_api('http://localhost:8080', method='post', data='data')
+          assert response['key1'] == 'test1' and response['key2'] == 'test2', "Test failed"
 
-      # Check the response status code
-      if response.status_code == 200:
-          # The API call was successful
-          print(response.json())
-      else:
-          # The API call failed
-          print('Error:', response.status_code)
+      if __name__ == '__main__':
+          test_call_api()
 
   anthropic_chat:
     name: Anthropic Chat

--- a/tests/integration/testcases.yaml
+++ b/tests/integration/testcases.yaml
@@ -161,7 +161,7 @@ testcases:
               "role":"user"
             }
         ],
-        "model":"Qwen/Qwen2.5-Coder-3B-Instruct",
+        "model":"Qwen/Qwen2.5-Coder-0.5B-Instruct",
         "stream":true,
         "temperature":0
       }
@@ -174,7 +174,7 @@ testcases:
     url: http://127.0.0.1:8989/vllm/completions
     data: |
       {
-        "model": "Qwen/Qwen2.5-Coder-3B-Instruct",
+        "model": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
         "max_tokens": 4096,
         "temperature": 0,
         "stream": true,

--- a/tests/integration/testcases.yaml
+++ b/tests/integration/testcases.yaml
@@ -161,7 +161,7 @@ testcases:
               "role":"user"
             }
         ],
-        "model":"Qwen/Qwen2.5-Coder-0.5B",
+        "model":"Qwen/Qwen2.5-Coder-0.5B-Instruct",
         "stream":true,
         "temperature":0
       }
@@ -174,7 +174,7 @@ testcases:
     url: http://127.0.0.1:8989/vllm/completions
     data: |
       {
-        "model": "Qwen/Qwen2.5-Coder-0.5B",
+        "model": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
         "max_tokens": 4096,
         "temperature": 0,
         "stream": true,


### PR DESCRIPTION
The following PR enables the integration tests for vllm.

**Details:**
* Starts the CodeGate container in the host network (so everything can talk to each other without the need to specify explict ports), we don't have port conflicts anyway
* Starts the vllm container, runs the `Qwen/Qwen2.5-Coder-0.5B-Instruct` model and verifies if it is serving as expected
* Updates the vllm tests to use `Qwen/Qwen2.5-Coder-0.5B-Instruct`
* Updates the chat test to expect a simpler welcome message
* Updates the vllm provider making the Authorization header optional

Fixes: https://github.com/stacklok/codegate/issues/816

Nit: For some reason I wasn't able to get vllm running on my Mac ([issue](https://github.com/vllm-project/vllm/issues/11814)).

**What's left:**
- [ ] Figure out why the FIM test is failing. Note that I tried with 1.5B and 3B models too. The 1.5B failed, whereas the 3B model took more than 1hr of CI to compute and I canceled it at the end, most certainly because we are running on CPU mode only in a low-performant environment). 

**Logs:**
* From trying with `Qwen/Qwen2.5-Coder-3B-Instruct` - https://github.com/stacklok/codegate/actions/runs/13030195063/job/36347712608?pr=806
* From trying with `Qwen/Qwen2.5-Coder-0.5B` https://github.com/stacklok/codegate/actions/runs/13032337694/job/36354452847?pr=806