### PR TITLE
Bootstrap provider with auth none

### DIFF
--- a/src/codegate/providers/crud/crud.py
+++ b/src/codegate/providers/crud/crud.py
@@ -185,6 +185,9 @@ async def try_initialize_provider_endpoints(
 ):
     try:
         models = pimpl.models()
+
+        # If we were able to get the models, we don't need auth
+        provend.auth_type = apimodelsv1.ProviderAuthType.none
     except Exception as err:
         logger.debug(
             "Unable to get models from provider",


### PR DESCRIPTION
This allows for the right type of authentication to be auto-discovered
in case we were able to get the models.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
