### PR TITLE
Create mux endpoint and route to appropriate destination provider

### DIFF
--- a/src/codegate/api/v1_models.py
+++ b/src/codegate/api/v1_models.py
@@ -107,25 +107,12 @@ class PartialQuestions(pydantic.BaseModel):
     type: QuestionType
 
 
-class ProviderType(str, Enum):
-    """
-    Represents the different types of providers we support.
-    """
-
-    openai = "openai"
-    anthropic = "anthropic"
-    vllm = "vllm"
-    ollama = "ollama"
-    lm_studio = "lm_studio"
-    llamacpp = "llamacpp"
-
-
 class TokenUsageByModel(pydantic.BaseModel):
     """
     Represents the tokens used by a model.
     """
 
-    provider_type: ProviderType
+    provider_type: db_models.ProviderType
     model: str
     token_usage: db_models.TokenUsage
 
@@ -221,7 +208,7 @@ class ProviderEndpoint(pydantic.BaseModel):
     id: Optional[str] = ""
     name: str
     description: str = ""
-    provider_type: ProviderType
+    provider_type: db_models.ProviderType
     endpoint: str = ""  # Some providers have defaults we can leverage
     auth_type: Optional[ProviderAuthType] = ProviderAuthType.none
 

--- a/src/codegate/db/models.py
+++ b/src/codegate/db/models.py
@@ -1,4 +1,5 @@
 import datetime
+from enum import Enum
 from typing import Annotated, Any, Dict, Optional
 
 from pydantic import BaseModel, StringConstraints
@@ -116,6 +117,19 @@ class Session(BaseModel):
 # Models for select queries
 
 
+class ProviderType(str, Enum):
+    """
+    Represents the different types of providers we support.
+    """
+
+    openai = "openai"
+    anthropic = "anthropic"
+    vllm = "vllm"
+    ollama = "ollama"
+    lm_studio = "lm_studio"
+    llamacpp = "llamacpp"
+
+
 class GetPromptWithOutputsRow(BaseModel):
     id: Any
     timestamp: Any
@@ -185,3 +199,19 @@ class MuxRule(BaseModel):
     priority: int
     created_at: Optional[datetime.datetime] = None
     updated_at: Optional[datetime.datetime] = None
+
+
+class MuxRuleProviderEndpoint(BaseModel):
+    id: str
+    provider_endpoint_id: str
+    provider_model_name: str
+    workspace_id: str
+    matcher_type: str
+    matcher_blob: str
+    priority: int
+    created_at: Optional[datetime.datetime] = None
+    updated_at: Optional[datetime.datetime] = None
+    provider_type: ProviderType
+    endpoint: str
+    auth_type: str
+    auth_blob: str

--- a/src/codegate/mux/adapter.py
+++ b/src/codegate/mux/adapter.py
@@ -1,6 +1,22 @@
 import copy
+import json
+import uuid
+from typing import Union
+
+import structlog
+from fastapi.responses import JSONResponse, StreamingResponse
+from litellm import ModelResponse
+from litellm.types.utils import Delta, StreamingChoices
+from ollama import ChatResponse
 
 from codegate.db import models as db_models
+from codegate.providers.ollama.adapter import OLlamaToModel
+
+logger = structlog.get_logger("codegate")
+
+
+class MuxingAdapterError(Exception):
+    pass
 
 
 class BodyAdapter:
@@ -39,6 +55,23 @@ class BodyAdapter:
             del new_body["system"]
         return new_body
 
+    def _get_provider_formatted_url(
+        self, mux_and_provider: db_models.MuxRuleProviderEndpoint
+    ) -> str:
+        """Get the provider formatted URL to use in base_url. Note this value comes from DB"""
+        if mux_and_provider.provider_type == db_models.ProviderType.openai:
+            return f"{mux_and_provider.endpoint}/v1"
+        return mux_and_provider.endpoint
+
+    def _set_destination_info(
+        self, data: dict, mux_and_provider: db_models.MuxRuleProviderEndpoint
+    ) -> dict:
+        """Set the destination provider info."""
+        new_data = copy.deepcopy(data)
+        new_data["model"] = mux_and_provider.provider_model_name
+        new_data["base_url"] = self._get_provider_formatted_url(mux_and_provider)
+        return new_data
+
     def _identify_provider(self, data: dict) -> db_models.ProviderType:
         """Identify the request provider."""
         if "system" in data:
@@ -46,20 +79,134 @@ class BodyAdapter:
         else:
             return db_models.ProviderType.openai
 
-    def map_body_to_dest(self, dest_prov: db_models.ProviderType, data: dict) -> dict:
+    def map_body_to_dest(
+        self, mux_and_provider: db_models.MuxRuleProviderEndpoint, data: dict
+    ) -> dict:
         """
         Map the body to the destination provider.
 
         We only need to transform the body if the destination or origin provider is Anthropic.
         """
         origin_prov = self._identify_provider(data)
-        if dest_prov == db_models.ProviderType.anthropic:
-            if origin_prov == db_models.ProviderType.anthropic:
-                return data
-            else:
-                return self._from_openai_to_antrhopic(data)
+        if mux_and_provider.provider_type == db_models.ProviderType.anthropic:
+            if origin_prov != db_models.ProviderType.anthropic:
+                data = self._from_openai_to_antrhopic(data)
         else:
             if origin_prov == db_models.ProviderType.anthropic:
-                return self._from_anthropic_to_openai(data)
-            else:
-                return data
+                data = self._from_anthropic_to_openai(data)
+        return self._set_destination_info(data, mux_and_provider)
+
+
+class StreamChunkFormatter:
+    """
+    Format a single chunk from a stream to OpenAI format.
+    We need to configure the client to expect the OpenAI format.
+    In Continue this means setting "provider": "openai" in the config json file.
+    """
+
+    def __init__(self):
+        self.provider_to_func = {
+            db_models.ProviderType.ollama: self._format_ollama,
+            db_models.ProviderType.openai: self._format_openai,
+            db_models.ProviderType.anthropic: self._format_antropic,
+        }
+
+    def _format_ollama(self, chunk: str) -> str:
+        """Format the Ollama chunk to OpenAI format."""
+        try:
+            chunk_dict = json.loads(chunk)
+            ollama_chunk = ChatResponse(**chunk_dict)
+            open_ai_chunk = OLlamaToModel.normalize_chunk(ollama_chunk)
+            return open_ai_chunk.model_dump_json(exclude_none=True, exclude_unset=True)
+        except Exception:
+            return chunk
+
+    def _format_openai(self, chunk: str) -> str:
+        """The chunk is already in OpenAI format. To standarize remove the "data:" prefix."""
+        cleaned_chunk = chunk.split("data:")[1].strip()
+        try:
+            chunk_dict = json.loads(cleaned_chunk)
+            open_ai_chunk = ModelResponse(**chunk_dict)
+            return open_ai_chunk.model_dump_json(exclude_none=True, exclude_unset=True)
+        except Exception:
+            return cleaned_chunk
+
+    def _format_antropic(self, chunk: str) -> str:
+        """Format the Anthropic chunk to OpenAI format."""
+        cleaned_chunk = chunk.split("data:")[1].strip()
+        try:
+            chunk_dict = json.loads(cleaned_chunk)
+            msg_type = chunk_dict.get("type", "")
+
+            finish_reason = None
+            if msg_type == "message_stop":
+                finish_reason = "stop"
+
+            # In type == "content_block_start" the content comes in "content_block"
+            # In type == "content_block_delta" the content comes in "delta"
+            msg_content_dict = chunk_dict.get("delta", {}) or chunk_dict.get("content_block", {})
+            # We couldn't obtain the content from the chunk. Skip it.
+            if not msg_content_dict:
+                return ""
+
+            msg_content = msg_content_dict.get("text", "")
+            open_ai_chunk = ModelResponse(
+                id=f"anthropic-chat-{str(uuid.uuid4())}",
+                model="anthropic-muxed-model",
+                object="chat.completion.chunk",
+                choices=[
+                    StreamingChoices(
+                        finish_reason=finish_reason,
+                        index=0,
+                        delta=Delta(content=msg_content, role="assistant"),
+                        logprobs=None,
+                    )
+                ],
+            )
+            return open_ai_chunk.model_dump_json(exclude_none=True, exclude_unset=True)
+        except Exception:
+            return cleaned_chunk.strip()
+
+    def format(self, chunk: str, dest_prov: db_models.ProviderType) -> ModelResponse:
+        """Format the chunk to OpenAI format."""
+        # Get the format function
+        format_func = self.provider_to_func.get(dest_prov)
+        if format_func is None:
+            raise MuxingAdapterError(f"Provider {dest_prov} not supported.")
+        return format_func(chunk)
+
+
+class ResponseAdapter:
+
+    def __init__(self):
+        self.stream_formatter = StreamChunkFormatter()
+
+    def _format_as_openai_chunk(self, formatted_chunk: str) -> str:
+        """Format the chunk as OpenAI chunk. This is the format how the clients expect the data."""
+        return f"data:{formatted_chunk}\n\n"
+
+    async def _format_streaming_response(
+        self, response: StreamingResponse, dest_prov: db_models.ProviderType
+    ):
+        """Format the streaming response to OpenAI format."""
+        async for chunk in response.body_iterator:
+            openai_chunk = self.stream_formatter.format(chunk, dest_prov)
+            # Sometimes for Anthropic we couldn't get content from the chunk. Skip it.
+            if not openai_chunk:
+                continue
+            yield self._format_as_openai_chunk(openai_chunk)
+
+    def format_response_to_client(
+        self, response: Union[StreamingResponse, JSONResponse], dest_prov: db_models.ProviderType
+    ) -> Union[StreamingResponse, JSONResponse]:
+        """Format the response to the client."""
+        if isinstance(response, StreamingResponse):
+            return StreamingResponse(
+                self._format_streaming_response(response, dest_prov),
+                status_code=response.status_code,
+                headers=response.headers,
+                background=response.background,
+                media_type=response.media_type,
+            )
+        else:
+            raise MuxingAdapterError("Only streaming responses are supported.")

--- a/src/codegate/mux/adapter.py
+++ b/src/codegate/mux/adapter.py
@@ -1,0 +1,65 @@
+import copy
+
+from codegate.db import models as db_models
+
+
+class BodyAdapter:
+    """
+    Map the body between OpenAI and Anthropic.
+
+    TODO: This are really knaive implementations. We should replace them with more robust ones.
+    """
+
+    def _from_openai_to_antrhopic(self, openai_body: dict) -> dict:
+        """Map the OpenAI body to the Anthropic body."""
+        new_body = copy.deepcopy(openai_body)
+        messages = new_body.get("messages", [])
+        system_prompt = None
+        system_msg_idx = None
+        if messages:
+            for i_msg, msg in enumerate(messages):
+                if msg.get("role", "") == "system":
+                    system_prompt = msg.get("content")
+                    system_msg_idx = i_msg
+                    break
+        if system_prompt:
+            new_body["system"] = system_prompt
+        if system_msg_idx is not None:
+            del messages[system_msg_idx]
+        return new_body
+
+    def _from_anthropic_to_openai(self, anthropic_body: dict) -> dict:
+        """Map the Anthropic body to the OpenAI body."""
+        new_body = copy.deepcopy(anthropic_body)
+        system_prompt = anthropic_body.get("system")
+        messages = new_body.get("messages", [])
+        if system_prompt:
+            messages.insert(0, {"role": "system", "content": system_prompt})
+        if "system" in new_body:
+            del new_body["system"]
+        return new_body
+
+    def _identify_provider(self, data: dict) -> db_models.ProviderType:
+        """Identify the request provider."""
+        if "system" in data:
+            return db_models.ProviderType.anthropic
+        else:
+            return db_models.ProviderType.openai
+
+    def map_body_to_dest(self, dest_prov: db_models.ProviderType, data: dict) -> dict:
+        """
+        Map the body to the destination provider.
+
+        We only need to transform the body if the destination or origin provider is Anthropic.
+        """
+        origin_prov = self._identify_provider(data)
+        if dest_prov == db_models.ProviderType.anthropic:
+            if origin_prov == db_models.ProviderType.anthropic:
+                return data
+            else:
+                return self._from_openai_to_antrhopic(data)
+        else:
+            if origin_prov == db_models.ProviderType.anthropic:
+                return self._from_anthropic_to_openai(data)
+            else:
+                return data

--- a/src/codegate/mux/router.py
+++ b/src/codegate/mux/router.py
@@ -1,0 +1,81 @@
+import json
+
+import structlog
+from fastapi import APIRouter, HTTPException, Request
+
+from codegate.db.models import MuxRuleProviderEndpoint
+from codegate.mux.adapter import BodyAdapter
+from codegate.providers.registry import ProviderRegistry
+from codegate.workspaces.crud import WorkspaceCrud
+
+logger = structlog.get_logger("codegate")
+
+
+class MuxRouter:
+    """
+    MuxRouter is a class that handles the muxing requests and routes them to
+    the correct destination provider.
+    """
+
+    def __init__(self, provider_registry: ProviderRegistry):
+        self._ws_crud = WorkspaceCrud()
+        self._adapter = BodyAdapter()
+        self.router = APIRouter()
+        self._setup_routes()
+        self._provider_registry = provider_registry
+
+    @property
+    def route_name(self) -> str:
+        return "v1/mux"
+
+    def get_routes(self) -> APIRouter:
+        return self.router
+
+    def _set_destination_info(self, data: dict, mux_and_provider: MuxRuleProviderEndpoint) -> dict:
+        data["model"] = mux_and_provider.provider_model_name
+        data["base_url"] = mux_and_provider.endpoint
+        return data
+
+    def _ensure_path_starts_with_slash(self, path: str) -> str:
+        return path if path.startswith("/") else f"/{path}"
+
+    def _setup_routes(self):
+
+        @self.router.post(f"/{self.route_name}/{{rest_of_path:path}}")
+        async def route_to_dest_provider(
+            request: Request,
+            rest_of_path: str = "",
+        ):
+            """
+            Route the request to the correct destination provider.
+
+            1. Get destination provider from DB and active workspace
+            2. Map the request body to the destination provider format
+            3. Run pipeline. Selecting the correct destination provider
+            4. Transmit the response back to the client
+            """
+
+            body = await request.body()
+            data = json.loads(body)
+
+            try:
+                active_ws_muxes = await self._ws_crud.get_active_workspace_muxes()
+            except Exception as e:
+                logger.error(f"Error getting active workspace muxes: {e}")
+                raise HTTPException(str(e))
+
+            # TODO: Implement the muxing logic here. For the moment we will assume
+            # that we have a single mux, i.e. a single destination provider.
+            if len(active_ws_muxes) == 0:
+                raise HTTPException(status_code=404, detail="No active workspace muxes found")
+            mux_and_provider = active_ws_muxes[0]
+
+            rest_of_path = self._ensure_path_starts_with_slash(rest_of_path)
+            new_data = self._adapter.map_body_to_dest(mux_and_provider.provider_type, data)
+            new_data = self._set_destination_info(new_data, mux_and_provider)
+            provider = self._provider_registry.get_provider(mux_and_provider.provider_type)
+
+            # TODO: Implement the logic to get the api_key from the DB
+            api_key = mux_and_provider.auth_blob
+
+            return await provider.process_request(new_data, api_key, rest_of_path)

--- a/src/codegate/providers/lm_studio/provider.py
+++ b/src/codegate/providers/lm_studio/provider.py
@@ -53,4 +53,4 @@ class LmStudioProvider(OpenAIProvider):
 
             data["base_url"] = self.lm_studio_url + "/v1/"
 
-            return await self.process_request(data, api_key, request)
+            return await self.process_request(data, api_key, request.url.path)

--- a/src/codegate/providers/openai/provider.py
+++ b/src/codegate/providers/openai/provider.py
@@ -42,11 +42,9 @@ class OpenAIProvider(BaseProvider):
 
         return [model["id"] for model in jsonresp.get("data", [])]
 
-    async def process_request(self, data: dict, api_key: str, request: Request):
-        """
-        Process the request and return the completion stream
-        """
-        is_fim_request = self._is_fim_request(request, data)
+    async def process_request(self, data: dict, api_key: str, request_url_path: str):
+        is_fim_request = self._is_fim_request(request_url_path, data)
+
         try:
             stream = await self.complete(data, api_key, is_fim_request=is_fim_request)
         except Exception as e:
@@ -82,4 +80,4 @@ class OpenAIProvider(BaseProvider):
             body = await request.body()
             data = json.loads(body)
 
-            return await self.process_request(data, api_key, request)
+            return await self.process_request(data, api_key, request.url.path)

--- a/src/codegate/server.py
+++ b/src/codegate/server.py
@@ -10,6 +10,8 @@ from starlette.middleware.errors import ServerErrorMiddleware
 
 from codegate import __description__, __version__
 from codegate.api.v1 import v1
+from codegate.db.models import ProviderType
+from codegate.mux.router import MuxRouter
 from codegate.pipeline.factory import PipelineFactory
 from codegate.providers.anthropic.provider import AnthropicProvider
 from codegate.providers.llamacpp.provider import LlamaCppProvider
@@ -70,39 +72,42 @@ def init_app(pipeline_factory: PipelineFactory) -> CodeGateServer:
 
     # Register all known providers
     registry.add_provider(
-        "openai",
+        ProviderType.openai,
         OpenAIProvider(pipeline_factory),
     )
     registry.add_provider(
-        "anthropic",
+        ProviderType.anthropic,
         AnthropicProvider(
             pipeline_factory,
         ),
     )
     registry.add_provider(
-        "llamacpp",
+        ProviderType.llamacpp,
         LlamaCppProvider(
             pipeline_factory,
         ),
     )
     registry.add_provider(
-        "vllm",
+        ProviderType.vllm,
         VLLMProvider(
             pipeline_factory,
         ),
     )
     registry.add_provider(
-        "ollama",
+        ProviderType.ollama,
         OllamaProvider(
             pipeline_factory,
         ),
     )
     registry.add_provider(
-        "lm_studio",
+        ProviderType.lm_studio,
         LmStudioProvider(
             pipeline_factory,
         ),
     )
+
+    mux_router = MuxRouter(registry)
+    app.include_router(mux_router.get_routes(), include_in_schema=False)
 
     # Create and add system routes
     system_router = APIRouter(tags=["System"])

--- a/tests/providers/test_registry.py
+++ b/tests/providers/test_registry.py
@@ -93,13 +93,16 @@ class MockProvider(BaseProvider):
     def provider_route_name(self) -> str:
         return "mock_provider"
 
+    async def process_request(self, data: dict, api_key: str, request_url_path: str):
+        return {"message": "test"}
+
     def models(self):
         return []
 
     def _setup_routes(self) -> None:
         @self.router.get(f"/{self.provider_route_name}/test")
-        def test_route():
-            return {"message": "test"}
+        async def test_route():
+            return await self.process_request({})
 
 
 @pytest.fixture

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -19,6 +19,9 @@ class MockProvider(BaseProvider):
             mocked_factory,
         )
 
+    async def process_request(self, data: dict, api_key: str, request_url_path: str):
+        return {"message": "test"}
+
     def models(self):
         return []
 
@@ -40,9 +43,7 @@ class MockProvider(BaseProvider):
 )
 def test_is_fim_request_url(url, expected_bool):
     mock_provider = MockProvider()
-    request = MagicMock()
-    request.url.path = url
-    assert mock_provider._is_fim_request_url(request) == expected_bool
+    assert mock_provider._is_fim_request_url(url) == expected_bool
 
 
 DATA_CONTENT_STR = {


### PR DESCRIPTION
Closes: #803 

This PR introduces the following changes related with muxing:
- Introduces a new route to which the muxing requests will go to: `/v1/mux`
- When hitting the above route the following steps will be performed
  1. The format of the request will be recognized. For the moment is only relevant to determine if the request has an Antropic body or an OpenAI body
  2. Get the destination provider from the active workspace configuration
  3. Transform the incoming request to the format of the destination provider
  4. Route the request to the adequate destination provider
- Introduction of a new method in all providers: `process_request`. The purpose of the method is to take the raw data, api_key and url path of the request and handle them appropriately. This is needed to support step number 4. above