### PR TITLE
Add client detection

### DIFF
--- a/src/codegate/clients/clients.py
+++ b/src/codegate/clients/clients.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class ClientType(Enum):
+    """
+    Enum of supported client types
+    """
+
+    GENERIC = "generic"  # Default client type when no specific client is detected
+    CLINE = "cline"  # Cline client
+    KODU = "kodu"  # Kodu client
+    COPILOT = "copilot"  # Copilot client
+    OPEN_INTERPRETER = "open_interpreter"  # Open Interpreter client

--- a/src/codegate/clients/detector.py
+++ b/src/codegate/clients/detector.py
@@ -1,0 +1,224 @@
+import re
+from abc import ABC, abstractmethod
+from functools import wraps
+from typing import List, Optional
+
+import structlog
+from fastapi import Request
+
+from codegate.clients.clients import ClientType
+
+logger = structlog.get_logger("codegate")
+
+
+class HeaderDetector:
+    """
+    Base utility class for header-based detection
+    """
+
+    def __init__(self, header_name: str, header_value: Optional[str] = None):
+        self.header_name = header_name
+        self.header_value = header_value
+
+    def detect(self, request: Request) -> bool:
+        logger.debug(
+            "checking header detection",
+            header_name=self.header_name,
+            header_value=self.header_value,
+            request_headers=dict(request.headers),
+        )
+        # Check if the header is present, if not we didn't detect the client
+        if self.header_name not in request.headers:
+            return False
+        # now we know that the header is present, if we don't care about the value
+        # we detected the client
+        if self.header_value is None:
+            return True
+        # finally, if we care about the value, we need to check if it matches
+        return request.headers[self.header_name] == self.header_value
+
+
+class UserAgentDetector(HeaderDetector):
+    """
+    A variant of the HeaderDetector that specifically looks for a user-agent pattern
+    """
+
+    def __init__(self, user_agent_pattern: str):
+        super().__init__("user-agent")
+        self.pattern = re.compile(user_agent_pattern, re.IGNORECASE)
+
+    def detect(self, request: Request) -> bool:
+        user_agent = request.headers.get(self.header_name)
+        if not user_agent:
+            return False
+        return bool(self.pattern.search(user_agent))
+
+
+class ContentDetector:
+    """
+    Detector for message content patterns
+    """
+
+    def __init__(self, pattern: str):
+        self.pattern = pattern
+
+    async def detect(self, request: Request) -> bool:
+        try:
+            data = await request.json()
+            for message in data.get("messages", []):
+                message_content = str(message.get("content", ""))
+                if self.pattern in message_content:
+                    return True
+            # This is clearly a hack and won't be needed when we get rid of the normalizers and will
+            # be able to access the system message directly from the on-wire format
+            system_content = str(data.get("system", ""))
+            if self.pattern in system_content:
+                return True
+            return False
+        except Exception as e:
+            logger.error(f"Error in content detection: {str(e)}")
+            return False
+
+
+class BaseClientDetector(ABC):
+    """
+    Base class for all client detectors using composition of detection methods
+    """
+
+    def __init__(self):
+        self.header_detector: Optional[HeaderDetector] = None
+        self.user_agent_detector: Optional[UserAgentDetector] = None
+        self.content_detector: Optional[ContentDetector] = None
+
+    @property
+    @abstractmethod
+    def client_name(self) -> ClientType:
+        """
+        Returns the name of the client
+        """
+        pass
+
+    async def detect(self, request: Request) -> bool:
+        """
+        Tries each configured detection method in sequence
+        """
+        # Try user agent first if configured
+        if self.user_agent_detector and self.user_agent_detector.detect(request):
+            return True
+
+        # Then try header if configured
+        if self.header_detector and self.header_detector.detect(request):
+            return True
+
+        # Finally try content if configured
+        if self.content_detector:
+            return await self.content_detector.detect(request)
+
+        return False
+
+
+class ClineDetector(BaseClientDetector):
+    """
+    Detector for Cline client based on message content
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.content_detector = ContentDetector("Cline")
+
+    @property
+    def client_name(self) -> ClientType:
+        return ClientType.CLINE
+
+
+class KoduDetector(BaseClientDetector):
+    """
+    Detector for Kodu client based on message content
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.user_agent_detector = UserAgentDetector("Kodu")
+        self.content_detector = ContentDetector("Kodu")
+
+    @property
+    def client_name(self) -> ClientType:
+        return ClientType.KODU
+
+
+class OpenInterpreter(BaseClientDetector):
+    """
+    Detector for Kodu client based on message content
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.content_detector = ContentDetector("Open Interpreter")
+
+    @property
+    def client_name(self) -> ClientType:
+        return ClientType.OPEN_INTERPRETER
+
+
+class CopilotDetector(HeaderDetector):
+    """
+    Detector for Copilot client based on user agent
+    """
+
+    def __init__(self):
+        super().__init__("user-agent", "Copilot")
+
+    @property
+    def client_name(self) -> ClientType:
+        return ClientType.COPILOT
+
+
+class DetectClient:
+    """
+    Decorator class for detecting clients from request system messages
+
+    Usage:
+        @app.post("/v1/chat/completions")
+        @DetectClient()
+        async def chat_completions(request: Request):
+            client = request.state.detected_client
+    """
+
+    def __init__(self):
+        self.detectors: List[BaseClientDetector] = [
+            ClineDetector(),
+            KoduDetector(),
+            OpenInterpreter(),
+            CopilotDetector(),
+        ]
+
+    def __call__(self, func):
+        @wraps(func)
+        async def wrapper(request: Request, *args, **kwargs):
+            try:
+                client = await self.detect(request)
+                request.state.detected_client = client
+            except Exception as e:
+                logger.error(f"Error in client detection: {str(e)}")
+                request.state.detected_client = ClientType.GENERIC
+
+            return await func(request, *args, **kwargs)
+
+        return wrapper
+
+    async def detect(self, request: Request) -> ClientType:
+        """
+        Detects the client from the request by trying each detector in sequence.
+        Returns the name of the first detected client, or GENERIC if no specific client is detected.
+        """
+        for detector in self.detectors:
+            try:
+                if await detector.detect(request):
+                    client_name = detector.client_name
+                    logger.info(f"{client_name} client detected")
+                    return client_name
+            except Exception as e:
+                logger.error(f"Error in {detector.client_name} detection: {str(e)}")
+                continue
+        logger.info("No particilar client detected, using generic client")
+        return ClientType.GENERIC

--- a/src/codegate/pipeline/base.py
+++ b/src/codegate/pipeline/base.py
@@ -11,9 +11,9 @@ import structlog
 from litellm import ChatCompletionRequest, ModelResponse
 from pydantic import BaseModel
 
+from codegate.clients.clients import ClientType
 from codegate.db.models import Alert, Output, Prompt
 from codegate.pipeline.secrets.manager import SecretsManager
-from codegate.utils.utils import get_tool_name_from_messages
 
 logger = structlog.get_logger("codegate")
 
@@ -81,6 +81,7 @@ class PipelineContext:
     shortcut_response: bool = False
     bad_packages_found: bool = False
     secrets_found: bool = False
+    client: ClientType = ClientType.GENERIC
 
     def add_code_snippet(self, snippet: CodeSnippet):
         self.code_snippets.append(snippet)
@@ -241,12 +242,14 @@ class PipelineStep(ABC):
     @staticmethod
     def get_last_user_message_block(
         request: ChatCompletionRequest,
+        client: ClientType = ClientType.GENERIC,
     ) -> Optional[tuple[str, int]]:
         """
         Get the last block of consecutive 'user' messages from the request.
 
         Args:
             request (ChatCompletionRequest): The chat completion request to process
+            client (ClientType): The client type to consider when processing the request
 
         Returns:
             Optional[str, int]: A string containing all consecutive user messages in the
@@ -261,9 +264,8 @@ class PipelineStep(ABC):
         messages = request["messages"]
         block_start_index = None
 
-        base_tool = get_tool_name_from_messages(request)
         accepted_roles = ["user", "assistant"]
-        if base_tool == "open interpreter":
+        if client == ClientType.OPEN_INTERPRETER:
             # open interpreter also uses the role "tool"
             accepted_roles.append("tool")
 
@@ -303,12 +305,16 @@ class PipelineStep(ABC):
 
 class InputPipelineInstance:
     def __init__(
-        self, pipeline_steps: List[PipelineStep], secret_manager: SecretsManager, is_fim: bool
+        self,
+        pipeline_steps: List[PipelineStep],
+        secret_manager: SecretsManager,
+        is_fim: bool,
+        client: ClientType = ClientType.GENERIC,
     ):
         self.pipeline_steps = pipeline_steps
         self.secret_manager = secret_manager
         self.is_fim = is_fim
-        self.context = PipelineContext()
+        self.context = PipelineContext(client=client)
 
         # we create the sesitive context here so that it is not shared between individual requests
         # TODO: could we get away with just generating the session ID for an instance?
@@ -367,16 +373,25 @@ class InputPipelineInstance:
 
 class SequentialPipelineProcessor:
     def __init__(
-        self, pipeline_steps: List[PipelineStep], secret_manager: SecretsManager, is_fim: bool
+        self,
+        pipeline_steps: List[PipelineStep],
+        secret_manager: SecretsManager,
+        client_type: ClientType,
+        is_fim: bool,
     ):
         self.pipeline_steps = pipeline_steps
         self.secret_manager = secret_manager
         self.is_fim = is_fim
-        self.instance = self._create_instance()
+        self.instance = self._create_instance(client_type)
 
-    def _create_instance(self) -> InputPipelineInstance:
+    def _create_instance(self, client_type: ClientType) -> InputPipelineInstance:
         """Create a new pipeline instance for processing a request"""
-        return InputPipelineInstance(self.pipeline_steps, self.secret_manager, self.is_fim)
+        return InputPipelineInstance(
+            self.pipeline_steps,
+            self.secret_manager,
+            self.is_fim,
+            client_type,
+        )
 
     async def process_request(
         self,

--- a/src/codegate/pipeline/base.py
+++ b/src/codegate/pipeline/base.py
@@ -332,7 +332,6 @@ class InputPipelineInstance:
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
         extra_headers: Optional[Dict[str, str]] = None,
-        is_copilot: bool = False,
     ) -> PipelineResult:
         """Process a request through all pipeline steps"""
         self.context.metadata["extra_headers"] = extra_headers
@@ -344,7 +343,9 @@ class InputPipelineInstance:
         self.context.sensitive.api_base = api_base
 
         # For Copilot provider=openai. Use a flag to not clash with other places that may use that.
-        provider_db = "copilot" if is_copilot else provider
+        provider_db = provider
+        if self.context.client == ClientType.COPILOT:
+            provider_db = "copilot"
 
         for step in self.pipeline_steps:
             result = await step.process(current_request, self.context)
@@ -401,9 +402,13 @@ class SequentialPipelineProcessor:
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
         extra_headers: Optional[Dict[str, str]] = None,
-        is_copilot: bool = False,
     ) -> PipelineResult:
         """Create a new pipeline instance and process the request"""
         return await self.instance.process_request(
-            request, provider, model, api_key, api_base, extra_headers, is_copilot
+            request,
+            provider,
+            model,
+            api_key,
+            api_base,
+            extra_headers,
         )

--- a/src/codegate/pipeline/codegate_context_retriever/codegate.py
+++ b/src/codegate/pipeline/codegate_context_retriever/codegate.py
@@ -60,7 +60,7 @@ class CodegateContextRetriever(PipelineStep):
         Use RAG DB to add context to the user request
         """
         # Get the latest user message
-        last_message = self.get_last_user_message_block(request)
+        last_message = self.get_last_user_message_block(request, context.client)
         if not last_message:
             return PipelineResult(request=request)
         user_message, last_user_idx = last_message

--- a/src/codegate/pipeline/codegate_context_retriever/codegate.py
+++ b/src/codegate/pipeline/codegate_context_retriever/codegate.py
@@ -4,6 +4,7 @@ import re
 import structlog
 from litellm import ChatCompletionRequest
 
+from codegate.clients.clients import ClientType
 from codegate.pipeline.base import (
     AlertSeverity,
     PipelineContext,
@@ -13,7 +14,7 @@ from codegate.pipeline.base import (
 from codegate.pipeline.extract_snippets.extract_snippets import extract_snippets
 from codegate.storage.storage_engine import StorageEngine
 from codegate.utils.package_extractor import PackageExtractor
-from codegate.utils.utils import generate_vector_string, get_tool_name_from_messages
+from codegate.utils.utils import generate_vector_string
 
 logger = structlog.get_logger("codegate")
 
@@ -128,14 +129,13 @@ class CodegateContextRetriever(PipelineStep):
             new_request = request.copy()
 
             # perform replacement in all the messages starting from this index
-            base_tool = get_tool_name_from_messages(request)
-            if base_tool != "open interpreter":
+            if context.client != ClientType.OPEN_INTERPRETER:
                 for i in range(last_user_idx, len(new_request["messages"])):
                     message = new_request["messages"][i]
                     message_str = str(message["content"])  # type: ignore
                     context_msg = message_str
                     # Add the context to the last user message
-                    if base_tool in ["cline", "kodu"]:
+                    if context.client in [ClientType.CLINE, ClientType.KODU]:
                         match = re.search(r"<task>\s*(.*?)\s*</task>(.*)", message_str, re.DOTALL)
                         if match:
                             task_content = match.group(1)  # Content within <task>...</task>

--- a/src/codegate/pipeline/extract_snippets/extract_snippets.py
+++ b/src/codegate/pipeline/extract_snippets/extract_snippets.py
@@ -150,7 +150,7 @@ class CodeSnippetExtractor(PipelineStep):
         request: ChatCompletionRequest,
         context: PipelineContext,
     ) -> PipelineResult:
-        last_message = self.get_last_user_message_block(request)
+        last_message = self.get_last_user_message_block(request, context.client)
         if not last_message:
             return PipelineResult(request=request, context=context)
         msg_content, _ = last_message

--- a/src/codegate/pipeline/secrets/secrets.py
+++ b/src/codegate/pipeline/secrets/secrets.py
@@ -272,7 +272,7 @@ class CodegateSecrets(PipelineStep):
         total_matches = []
 
         # get last user message block to get index for the first relevant user message
-        last_user_message = self.get_last_user_message_block(new_request)
+        last_user_message = self.get_last_user_message_block(new_request, context.client)
         last_assistant_idx = -1
         if last_user_message:
             _, user_idx = last_user_message

--- a/src/codegate/providers/anthropic/completion_handler.py
+++ b/src/codegate/providers/anthropic/completion_handler.py
@@ -16,7 +16,6 @@ class AnthropicCompletion(LiteLLmShim):
         api_key: Optional[str],
         stream: bool = False,
         is_fim_request: bool = False,
-        base_tool: Optional[str] = "",
     ) -> Union[ModelResponse, AsyncIterator[ModelResponse]]:
         """
         Ensures the model name is prefixed with 'anthropic/' to explicitly route to Anthropic's API.

--- a/src/codegate/providers/anthropic/provider.py
+++ b/src/codegate/providers/anthropic/provider.py
@@ -62,7 +62,7 @@ class AnthropicProvider(BaseProvider):
     ):
         is_fim_request = self._is_fim_request(request_url_path, data)
         try:
-            stream = await self.complete(data, api_key, is_fim_request)
+            stream = await self.complete(data, api_key, is_fim_request, client_type)
         except Exception as e:
             #  check if we have an status code there
             if hasattr(e, "status_code"):

--- a/src/codegate/providers/anthropic/provider.py
+++ b/src/codegate/providers/anthropic/provider.py
@@ -5,6 +5,8 @@ import httpx
 import structlog
 from fastapi import Header, HTTPException, Request
 
+from codegate.clients.clients import ClientType
+from codegate.clients.detector import DetectClient
 from codegate.pipeline.factory import PipelineFactory
 from codegate.providers.anthropic.adapter import AnthropicInputNormalizer, AnthropicOutputNormalizer
 from codegate.providers.anthropic.completion_handler import AnthropicCompletion
@@ -51,7 +53,13 @@ class AnthropicProvider(BaseProvider):
 
         return [model["id"] for model in respjson.get("data", [])]
 
-    async def process_request(self, data: dict, api_key: str, request_url_path: str):
+    async def process_request(
+        self,
+        data: dict,
+        api_key: str,
+        request_url_path: str,
+        client_type: ClientType,
+    ):
         is_fim_request = self._is_fim_request(request_url_path, data)
         try:
             stream = await self.complete(data, api_key, is_fim_request)
@@ -65,7 +73,7 @@ class AnthropicProvider(BaseProvider):
             else:
                 # just continue raising the exception
                 raise e
-        return self._completion_handler.create_response(stream)
+        return self._completion_handler.create_response(stream, client_type)
 
     def _setup_routes(self):
         """
@@ -80,6 +88,7 @@ class AnthropicProvider(BaseProvider):
 
         @self.router.post(f"/{self.provider_route_name}/messages")
         @self.router.post(f"/{self.provider_route_name}/v1/messages")
+        @DetectClient()
         async def create_message(
             request: Request,
             x_api_key: str = Header(None),
@@ -90,4 +99,9 @@ class AnthropicProvider(BaseProvider):
             body = await request.body()
             data = json.loads(body)
 
-            return await self.process_request(data, x_api_key, request.url.path)
+            return await self.process_request(
+                data,
+                x_api_key,
+                request.url.path,
+                request.state.detected_client,
+            )

--- a/src/codegate/providers/base.py
+++ b/src/codegate/providers/base.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter
 from litellm import ModelResponse
 from litellm.types.llms.openai import ChatCompletionRequest
 
+from codegate.clients.clients import ClientType
 from codegate.codegate_logging import setup_logging
 from codegate.db.connection import DbRecorder
 from codegate.pipeline.base import (
@@ -22,7 +23,6 @@ from codegate.providers.completion.base import BaseCompletionHandler
 from codegate.providers.formatting.input_pipeline import PipelineResponseFormatter
 from codegate.providers.normalizer.base import ModelInputNormalizer, ModelOutputNormalizer
 from codegate.providers.normalizer.completion import CompletionNormalizer
-from codegate.utils.utils import get_tool_name_from_messages
 
 setup_logging()
 logger = structlog.get_logger("codegate")
@@ -74,7 +74,13 @@ class BaseProvider(ABC):
         pass
 
     @abstractmethod
-    async def process_request(self, data: dict, api_key: str, request_url_path: str):
+    async def process_request(
+        self,
+        data: dict,
+        api_key: str,
+        request_url_path: str,
+        client_type: ClientType,
+    ):
         pass
 
     @property
@@ -287,14 +293,11 @@ class BaseProvider(ABC):
         # Execute the completion and translate the response
         # This gives us either a single response or a stream of responses
         # based on the streaming flag
-        base_tool = get_tool_name_from_messages(data)
-
         model_response = await self._completion_handler.execute_completion(
             provider_request,
             api_key=api_key,
             stream=streaming,
             is_fim_request=is_fim_request,
-            base_tool=base_tool,
         )
         if not streaming:
             normalized_response = self._output_normalizer.normalize(model_response)

--- a/src/codegate/providers/completion/base.py
+++ b/src/codegate/providers/completion/base.py
@@ -6,6 +6,8 @@ from typing import Any, AsyncIterator, Optional, Union
 from fastapi.responses import JSONResponse, StreamingResponse
 from litellm import ChatCompletionRequest, ModelResponse
 
+from codegate.clients.clients import ClientType
+
 
 class BaseCompletionHandler(ABC):
     """
@@ -20,20 +22,27 @@ class BaseCompletionHandler(ABC):
         api_key: Optional[str],
         stream: bool = False,  # TODO: remove this param?
         is_fim_request: bool = False,
-        base_tool: Optional[str] = "",
     ) -> Union[ModelResponse, AsyncIterator[ModelResponse]]:
         """Execute the completion request"""
         pass
 
     @abstractmethod
-    def _create_streaming_response(self, stream: AsyncIterator[Any]) -> StreamingResponse:
+    def _create_streaming_response(
+        self,
+        stream: AsyncIterator[Any],
+        client_type: ClientType = ClientType.GENERIC,
+    ) -> StreamingResponse:
         pass
 
     @abstractmethod
     def _create_json_response(self, response: Any) -> JSONResponse:
         pass
 
-    def create_response(self, response: Any) -> Union[JSONResponse, StreamingResponse]:
+    def create_response(
+        self,
+        response: Any,
+        client_type: ClientType,
+    ) -> Union[JSONResponse, StreamingResponse]:
         """
         Create a FastAPI response from the completion response.
         """
@@ -42,5 +51,5 @@ class BaseCompletionHandler(ABC):
             or isinstance(response, AsyncIterator)
             or inspect.isasyncgen(response)
         ):
-            return self._create_streaming_response(response)
+            return self._create_streaming_response(response, client_type)
         return self._create_json_response(response)

--- a/src/codegate/providers/copilot/pipeline.py
+++ b/src/codegate/providers/copilot/pipeline.py
@@ -8,6 +8,7 @@ from litellm import ModelResponse
 from litellm.types.llms.openai import ChatCompletionRequest
 from litellm.types.utils import Delta, StreamingChoices
 
+from codegate.clients.clients import ClientType
 from codegate.pipeline.base import PipelineContext, PipelineResult, SequentialPipelineProcessor
 from codegate.pipeline.factory import PipelineFactory
 from codegate.providers.normalizer.completion import CompletionNormalizer
@@ -200,7 +201,7 @@ class CopilotFimPipeline(CopilotPipeline):
         return CopilotFimNormalizer()
 
     def _create_pipeline(self) -> SequentialPipelineProcessor:
-        return self.pipeline_factory.create_fim_pipeline()
+        return self.pipeline_factory.create_fim_pipeline(ClientType.COPILOT)
 
 
 class CopilotChatPipeline(CopilotPipeline):
@@ -216,4 +217,4 @@ class CopilotChatPipeline(CopilotPipeline):
         return CopilotChatNormalizer()
 
     def _create_pipeline(self) -> SequentialPipelineProcessor:
-        return self.pipeline_factory.create_input_pipeline()
+        return self.pipeline_factory.create_input_pipeline(ClientType.COPILOT)

--- a/src/codegate/providers/copilot/pipeline.py
+++ b/src/codegate/providers/copilot/pipeline.py
@@ -114,7 +114,6 @@ class CopilotPipeline(ABC):
                 api_key=headers_dict.get("authorization", "").replace("Bearer ", ""),
                 api_base="https://" + headers_dict.get("host", ""),
                 extra_headers=CopilotPipeline._get_copilot_headers(headers_dict),
-                is_copilot=True,
             )
         except Exception as e:
             logger.error(f"Pipeline processing error: {e}")

--- a/src/codegate/providers/litellmshim/litellmshim.py
+++ b/src/codegate/providers/litellmshim/litellmshim.py
@@ -9,6 +9,7 @@ from litellm import (
     acompletion,
 )
 
+from codegate.clients.clients import ClientType
 from codegate.providers.base import BaseCompletionHandler, StreamGenerator
 
 logger = structlog.get_logger("codegate")
@@ -43,7 +44,6 @@ class LiteLLmShim(BaseCompletionHandler):
         api_key: Optional[str],
         stream: bool = False,
         is_fim_request: bool = False,
-        base_tool: Optional[str] = "",
     ) -> Union[ModelResponse, AsyncIterator[ModelResponse]]:
         """
         Execute the completion request with LiteLLM's API
@@ -53,7 +53,11 @@ class LiteLLmShim(BaseCompletionHandler):
             return await self._fim_completion_func(**request)
         return await self._completion_func(**request)
 
-    def _create_streaming_response(self, stream: AsyncIterator[Any]) -> StreamingResponse:
+    def _create_streaming_response(
+        self,
+        stream: AsyncIterator[Any],
+        _: ClientType = ClientType.GENERIC,
+    ) -> StreamingResponse:
         """
         Create a streaming response from a stream generator. The StreamingResponse
         is the format that FastAPI expects for streaming responses.

--- a/src/codegate/providers/llamacpp/completion_handler.py
+++ b/src/codegate/providers/llamacpp/completion_handler.py
@@ -8,6 +8,7 @@ from llama_cpp.llama_types import (
     CreateChatCompletionStreamResponse,
 )
 
+from codegate.clients.clients import ClientType
 from codegate.config import Config
 from codegate.inference.inference_engine import LlamaCppInferenceEngine
 from codegate.providers.base import BaseCompletionHandler
@@ -52,7 +53,6 @@ class LlamaCppCompletionHandler(BaseCompletionHandler):
         api_key: Optional[str],
         stream: bool = False,
         is_fim_request: bool = False,
-        base_tool: Optional[str] = "",
     ) -> Union[ModelResponse, AsyncIterator[ModelResponse]]:
         """
         Execute the completion request with inference engine API
@@ -85,7 +85,11 @@ class LlamaCppCompletionHandler(BaseCompletionHandler):
 
         return convert_to_async_iterator(response) if stream else response
 
-    def _create_streaming_response(self, stream: AsyncIterator[Any]) -> StreamingResponse:
+    def _create_streaming_response(
+        self,
+        stream: AsyncIterator[Any],
+        client_type: ClientType = ClientType.GENERIC,
+    ) -> StreamingResponse:
         """
         Create a streaming response from a stream generator. The StreamingResponse
         is the format that FastAPI expects for streaming responses.

--- a/src/codegate/providers/llamacpp/provider.py
+++ b/src/codegate/providers/llamacpp/provider.py
@@ -54,7 +54,9 @@ class LlamaCppProvider(BaseProvider):
     ):
         is_fim_request = self._is_fim_request(request_url_path, data)
         try:
-            stream = await self.complete(data, None, is_fim_request=is_fim_request)
+            stream = await self.complete(
+                data, None, is_fim_request=is_fim_request, client_type=client_type
+            )
         except RuntimeError as e:
             # propagate as error 500
             logger.error("Error in LlamaCppProvider completion", error=str(e))

--- a/src/codegate/providers/llamacpp/provider.py
+++ b/src/codegate/providers/llamacpp/provider.py
@@ -5,6 +5,8 @@ from typing import List
 import structlog
 from fastapi import HTTPException, Request
 
+from codegate.clients.clients import ClientType
+from codegate.clients.detector import DetectClient
 from codegate.config import Config
 from codegate.pipeline.factory import PipelineFactory
 from codegate.providers.base import BaseProvider, ModelFetchError
@@ -43,7 +45,13 @@ class LlamaCppProvider(BaseProvider):
             if model.is_file() and model.stem != "all-minilm-L6-v2-q5_k_m"
         ]
 
-    async def process_request(self, data: dict, api_key: str, request_url_path: str):
+    async def process_request(
+        self,
+        data: dict,
+        api_key: str,
+        request_url_path: str,
+        client_type: ClientType,
+    ):
         is_fim_request = self._is_fim_request(request_url_path, data)
         try:
             stream = await self.complete(data, None, is_fim_request=is_fim_request)
@@ -61,7 +69,7 @@ class LlamaCppProvider(BaseProvider):
             else:
                 # just continue raising the exception
                 raise e
-        return self._completion_handler.create_response(stream)
+        return self._completion_handler.create_response(stream, client_type)
 
     def _setup_routes(self):
         """
@@ -71,11 +79,16 @@ class LlamaCppProvider(BaseProvider):
 
         @self.router.post(f"/{self.provider_route_name}/completions")
         @self.router.post(f"/{self.provider_route_name}/chat/completions")
+        @DetectClient()
         async def create_completion(
             request: Request,
         ):
             body = await request.body()
             data = json.loads(body)
             data["base_url"] = Config.get_config().model_base_path
-
-            return await self.process_request(data, None, request.url.path)
+            return await self.process_request(
+                data,
+                None,
+                request.url.path,
+                request.state.detected_client,
+            )

--- a/src/codegate/providers/ollama/provider.py
+++ b/src/codegate/providers/ollama/provider.py
@@ -5,6 +5,8 @@ import httpx
 import structlog
 from fastapi import HTTPException, Request
 
+from codegate.clients.clients import ClientType
+from codegate.clients.detector import DetectClient
 from codegate.config import Config
 from codegate.pipeline.factory import PipelineFactory
 from codegate.providers.base import BaseProvider, ModelFetchError
@@ -55,7 +57,13 @@ class OllamaProvider(BaseProvider):
 
         return [model["name"] for model in jsonresp.get("models", [])]
 
-    async def process_request(self, data: dict, api_key: str, request_url_path: str):
+    async def process_request(
+        self,
+        data: dict,
+        api_key: str,
+        request_url_path: str,
+        client_type: ClientType,
+    ):
         is_fim_request = self._is_fim_request(request_url_path, data)
         try:
             stream = await self.complete(data, api_key=None, is_fim_request=is_fim_request)
@@ -71,7 +79,7 @@ class OllamaProvider(BaseProvider):
             else:
                 # just continue raising the exception
                 raise e
-        return self._completion_handler.create_response(stream)
+        return self._completion_handler.create_response(stream, client_type)
 
     def _setup_routes(self):
         """
@@ -117,6 +125,7 @@ class OllamaProvider(BaseProvider):
         # Cline API routes
         @self.router.post(f"/{self.provider_route_name}/v1/chat/completions")
         @self.router.post(f"/{self.provider_route_name}/v1/generate")
+        @DetectClient()
         async def create_completion(request: Request):
             body = await request.body()
             data = json.loads(body)
@@ -125,4 +134,9 @@ class OllamaProvider(BaseProvider):
             # Force it to be the one that comes in the configuration.
             data["base_url"] = self.base_url
 
-            return await self.process_request(data, None, request.url.path)
+            return await self.process_request(
+                data,
+                None,
+                request.url.path,
+                request.state.detected_client,
+            )

--- a/src/codegate/providers/ollama/provider.py
+++ b/src/codegate/providers/ollama/provider.py
@@ -66,7 +66,12 @@ class OllamaProvider(BaseProvider):
     ):
         is_fim_request = self._is_fim_request(request_url_path, data)
         try:
-            stream = await self.complete(data, api_key=None, is_fim_request=is_fim_request)
+            stream = await self.complete(
+                data,
+                api_key=None,
+                is_fim_request=is_fim_request,
+                client_type=client_type,
+            )
         except httpx.ConnectError as e:
             logger.error("Error in OllamaProvider completion", error=str(e))
             raise HTTPException(status_code=503, detail="Ollama service is unavailable")

--- a/src/codegate/providers/openai/provider.py
+++ b/src/codegate/providers/openai/provider.py
@@ -54,7 +54,12 @@ class OpenAIProvider(BaseProvider):
         is_fim_request = self._is_fim_request(request_url_path, data)
 
         try:
-            stream = await self.complete(data, api_key, is_fim_request=is_fim_request)
+            stream = await self.complete(
+                data,
+                api_key,
+                is_fim_request=is_fim_request,
+                client_type=client_type,
+            )
         except Exception as e:
             #  check if we have an status code there
             if hasattr(e, "status_code"):

--- a/src/codegate/providers/openai/provider.py
+++ b/src/codegate/providers/openai/provider.py
@@ -5,6 +5,8 @@ import httpx
 import structlog
 from fastapi import Header, HTTPException, Request
 
+from codegate.clients.clients import ClientType
+from codegate.clients.detector import DetectClient
 from codegate.pipeline.factory import PipelineFactory
 from codegate.providers.base import BaseProvider, ModelFetchError
 from codegate.providers.litellmshim import LiteLLmShim, sse_stream_generator
@@ -42,7 +44,13 @@ class OpenAIProvider(BaseProvider):
 
         return [model["id"] for model in jsonresp.get("data", [])]
 
-    async def process_request(self, data: dict, api_key: str, request_url_path: str):
+    async def process_request(
+        self,
+        data: dict,
+        api_key: str,
+        request_url_path: str,
+        client_type: ClientType,
+    ):
         is_fim_request = self._is_fim_request(request_url_path, data)
 
         try:
@@ -57,7 +65,7 @@ class OpenAIProvider(BaseProvider):
             else:
                 # just continue raising the exception
                 raise e
-        return self._completion_handler.create_response(stream)
+        return self._completion_handler.create_response(stream, client_type)
 
     def _setup_routes(self):
         """
@@ -69,6 +77,7 @@ class OpenAIProvider(BaseProvider):
         @self.router.post(f"/{self.provider_route_name}/chat/completions")
         @self.router.post(f"/{self.provider_route_name}/completions")
         @self.router.post(f"/{self.provider_route_name}/v1/chat/completions")
+        @DetectClient()
         async def create_completion(
             request: Request,
             authorization: str = Header(..., description="Bearer token"),
@@ -80,4 +89,9 @@ class OpenAIProvider(BaseProvider):
             body = await request.body()
             data = json.loads(body)
 
-            return await self.process_request(data, api_key, request.url.path)
+            return await self.process_request(
+                data,
+                api_key,
+                request.url.path,
+                request.state.detected_client,
+            )

--- a/src/codegate/providers/vllm/provider.py
+++ b/src/codegate/providers/vllm/provider.py
@@ -7,6 +7,8 @@ import structlog
 from fastapi import Header, HTTPException, Request
 from litellm import atext_completion
 
+from codegate.clients.clients import ClientType
+from codegate.clients.detector import DetectClient
 from codegate.config import Config
 from codegate.pipeline.factory import PipelineFactory
 from codegate.providers.base import BaseProvider, ModelFetchError
@@ -65,7 +67,13 @@ class VLLMProvider(BaseProvider):
 
         return [model["id"] for model in jsonresp.get("data", [])]
 
-    async def process_request(self, data: dict, api_key: str, request_url_path: str):
+    async def process_request(
+        self,
+        data: dict,
+        api_key: str,
+        request_url_path: str,
+        client_type: ClientType,
+    ):
         is_fim_request = self._is_fim_request(request_url_path, data)
         try:
             # Pass the potentially None api_key to complete
@@ -77,7 +85,7 @@ class VLLMProvider(BaseProvider):
                 logger.error("Error in VLLMProvider completion", error=str(e))
                 raise HTTPException(status_code=e.status_code, detail=str(e))
             raise e
-        return self._completion_handler.create_response(stream)
+        return self._completion_handler.create_response(stream, client_type)
 
     def _setup_routes(self):
         """
@@ -116,6 +124,7 @@ class VLLMProvider(BaseProvider):
 
         @self.router.post(f"/{self.provider_route_name}/chat/completions")
         @self.router.post(f"/{self.provider_route_name}/completions")
+        @DetectClient()
         async def create_completion(
             request: Request,
             authorization: str | None = Header(None, description="Optional Bearer token"),
@@ -135,4 +144,9 @@ class VLLMProvider(BaseProvider):
             base_url = self._get_base_url()
             data["base_url"] = base_url
 
-            return await self.process_request(data, api_key, request.url.path)
+            return await self.process_request(
+                data,
+                api_key,
+                request.url.path,
+                request.state.detected_client,
+            )

--- a/src/codegate/providers/vllm/provider.py
+++ b/src/codegate/providers/vllm/provider.py
@@ -77,7 +77,12 @@ class VLLMProvider(BaseProvider):
         is_fim_request = self._is_fim_request(request_url_path, data)
         try:
             # Pass the potentially None api_key to complete
-            stream = await self.complete(data, api_key, is_fim_request=is_fim_request)
+            stream = await self.complete(
+                data,
+                api_key,
+                is_fim_request=is_fim_request,
+                client_type=client_type,
+            )
         except Exception as e:
             # Check if we have a status code there
             if hasattr(e, "status_code"):

--- a/src/codegate/utils/utils.py
+++ b/src/codegate/utils/utils.py
@@ -32,23 +32,3 @@ def generate_vector_string(package) -> str:
     # add description
     vector_str += f" - Package offers this functionality: {package['description']}"
     return vector_str
-
-
-def get_tool_name_from_messages(data):
-    """
-    Identifies the tool name based on the content of the messages.
-
-    Args:
-        request (dict): The request object containing messages.
-        tools (list): A list of tool names to search for.
-
-    Returns:
-        str: The name of the tool found in the messages, or None if no match is found.
-    """
-    tools = ["Cline", "Kodu", "Open Interpreter", "Aider"]
-    for message in data.get("messages", []):
-        message_content = str(message.get("content", ""))
-        for tool in tools:
-            if tool in message_content:
-                return tool.lower()
-    return None

--- a/tests/clients/test_detector.py
+++ b/tests/clients/test_detector.py
@@ -1,0 +1,355 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+from fastapi import Request
+from fastapi.datastructures import Headers
+
+from codegate.clients.clients import ClientType
+from codegate.clients.detector import (
+    BaseClientDetector,
+    ClineDetector,
+    ContentDetector,
+    CopilotDetector,
+    DetectClient,
+    HeaderDetector,
+    KoduDetector,
+    OpenInterpreter,
+    UserAgentDetector,
+)
+
+
+@pytest.fixture
+def mock_request():
+    """Create a mock FastAPI request with configurable headers and body"""
+
+    async def get_json():
+        return {"messages": []}
+
+    request = Mock(spec=Request)
+    request.headers = Headers()
+    request.json = get_json
+    return request
+
+
+@pytest.fixture
+def mock_request_with_messages(mock_request):
+    """Create a mock request with configurable message content"""
+
+    async def get_json():
+        return {
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "system", "content": "Test message"},
+            ]
+        }
+
+    mock_request.json = get_json
+    return mock_request
+
+
+class TestHeaderDetector:
+    def test_header_present_with_matching_value(self, mock_request):
+        detector = HeaderDetector("X-Test-Header", "test-value")
+        mock_request.headers = Headers({"X-Test-Header": "test-value"})
+        assert detector.detect(mock_request) is True
+
+    def test_header_present_without_value_check(self, mock_request):
+        detector = HeaderDetector("X-Test-Header")
+        mock_request.headers = Headers({"X-Test-Header": "any-value"})
+        assert detector.detect(mock_request) is True
+
+    def test_header_missing(self, mock_request):
+        detector = HeaderDetector("X-Test-Header", "test-value")
+        assert detector.detect(mock_request) is False
+
+    def test_header_present_with_non_matching_value(self, mock_request):
+        detector = HeaderDetector("X-Test-Header", "test-value")
+        mock_request.headers = Headers({"X-Test-Header": "wrong-value"})
+        assert detector.detect(mock_request) is False
+
+
+class TestUserAgentDetector:
+    def test_matching_user_agent_pattern(self, mock_request):
+        detector = UserAgentDetector("Test.*Browser")
+        mock_request.headers = Headers({"user-agent": "Test/1.0 Browser"})
+        assert detector.detect(mock_request) is True
+
+    def test_non_matching_user_agent_pattern(self, mock_request):
+        detector = UserAgentDetector("Test.*Browser")
+        mock_request.headers = Headers({"user-agent": "Different/1.0 Agent"})
+        assert detector.detect(mock_request) is False
+
+    def test_missing_user_agent(self, mock_request):
+        detector = UserAgentDetector("Test.*Browser")
+        assert detector.detect(mock_request) is False
+
+    def test_case_insensitive_matching(self, mock_request):
+        detector = UserAgentDetector("test.*browser")
+        mock_request.headers = Headers({"user-agent": "TEST/1.0 BROWSER"})
+        assert detector.detect(mock_request) is True
+
+
+class TestContentDetector:
+    @pytest.mark.asyncio
+    async def test_matching_content_pattern(self, mock_request):
+        detector = ContentDetector("test-pattern")
+
+        async def get_json():
+            return {"messages": [{"content": "this is a test-pattern message"}]}
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is True
+
+    @pytest.mark.asyncio
+    async def test_non_matching_content_pattern(self, mock_request):
+        detector = ContentDetector("test-pattern")
+
+        async def get_json():
+            return {"messages": [{"content": "this is a different message"}]}
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is False
+
+    @pytest.mark.asyncio
+    async def test_malformed_json(self, mock_request):
+        detector = ContentDetector("test-pattern")
+
+        async def get_json():
+            raise json.JSONDecodeError("Invalid JSON", "", 0)
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is False
+
+    @pytest.mark.asyncio
+    async def test_empty_messages(self, mock_request):
+        detector = ContentDetector("test-pattern")
+
+        async def get_json():
+            return {"messages": []}
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is False
+
+    @pytest.mark.asyncio
+    async def test_missing_content_field(self, mock_request):
+        detector = ContentDetector("test-pattern")
+
+        async def get_json():
+            return {"messages": [{"role": "user"}]}
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is False
+
+
+class MockClientDetector(BaseClientDetector):
+    """Mock implementation of BaseClientDetector for testing"""
+
+    @property
+    def client_name(self) -> ClientType:
+        return ClientType.GENERIC
+
+
+class TestBaseClientDetector:
+    @pytest.mark.asyncio
+    async def test_user_agent_detection(self, mock_request):
+        detector = MockClientDetector()
+        detector.user_agent_detector = UserAgentDetector("Test.*Browser")
+        mock_request.headers = Headers({"user-agent": "Test/1.0 Browser"})
+        assert await detector.detect(mock_request) is True
+
+    @pytest.mark.asyncio
+    async def test_header_detection(self, mock_request):
+        detector = MockClientDetector()
+        detector.header_detector = HeaderDetector("X-Test", "value")
+        mock_request.headers = Headers({"X-Test": "value"})
+        assert await detector.detect(mock_request) is True
+
+    @pytest.mark.asyncio
+    async def test_content_detection(self, mock_request):
+        detector = MockClientDetector()
+        detector.content_detector = ContentDetector("test-pattern")
+
+        async def get_json():
+            return {"messages": [{"content": "test-pattern"}]}
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is True
+
+    @pytest.mark.asyncio
+    async def test_no_detectors_configured(self, mock_request):
+        detector = MockClientDetector()
+        assert await detector.detect(mock_request) is False
+
+
+class TestClineDetector:
+    @pytest.mark.asyncio
+    async def test_successful_detection(self, mock_request):
+        detector = ClineDetector()
+
+        async def get_json():
+            return {"messages": [{"content": "Cline"}]}
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is True
+        assert detector.client_name == ClientType.CLINE
+
+    @pytest.mark.asyncio
+    async def test_failed_detection(self, mock_request):
+        detector = ClineDetector()
+
+        async def get_json():
+            return {"messages": [{"content": "Different Client"}]}
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is False
+
+
+class TestKoduDetector:
+    @pytest.mark.asyncio
+    async def test_user_agent_detection(self, mock_request):
+        detector = KoduDetector()
+        mock_request.headers = Headers({"user-agent": "Kodu"})
+        assert await detector.detect(mock_request) is True
+        assert detector.client_name == ClientType.KODU
+
+    @pytest.mark.asyncio
+    async def test_content_detection(self, mock_request):
+        detector = KoduDetector()
+        mock_request.headers = Headers({"user-agent": "Different Client"})
+
+        async def get_json():
+            return {"messages": [{"content": "Kodu"}]}
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is True
+        assert detector.client_name == ClientType.KODU
+
+    @pytest.mark.asyncio
+    async def test_failed_detection(self, mock_request):
+        detector = KoduDetector()
+        mock_request.headers = Headers({"user-agent": "Different Client"})
+
+        async def get_json():
+            return {"messages": [{"content": "Different Client"}]}
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is False
+
+    @pytest.mark.asyncio
+    async def test_no_user_agent_content_detection(self, mock_request):
+        detector = KoduDetector()
+
+        async def get_json():
+            return {"messages": [{"content": "Kodu"}]}
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is True
+        assert detector.client_name == ClientType.KODU
+
+
+class TestOpenInterpreterDetector:
+    @pytest.mark.asyncio
+    async def test_successful_detection(self, mock_request):
+        detector = OpenInterpreter()
+
+        async def get_json():
+            return {"messages": [{"content": "Open Interpreter"}]}
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is True
+        assert detector.client_name == ClientType.OPEN_INTERPRETER
+
+    @pytest.mark.asyncio
+    async def test_failed_detection(self, mock_request):
+        detector = OpenInterpreter()
+
+        async def get_json():
+            return {"messages": [{"content": "Different Client"}]}
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is False
+
+
+class TestCopilotDetector:
+    def test_successful_detection(self, mock_request):
+        detector = CopilotDetector()
+        mock_request.headers = Headers({"user-agent": "Copilot"})
+        assert detector.detect(mock_request) is True
+        assert detector.client_name == ClientType.COPILOT
+
+    def test_failed_detection(self, mock_request):
+        detector = CopilotDetector()
+        mock_request.headers = Headers({"user-agent": "Different Client"})
+        assert detector.detect(mock_request) is False
+
+    def test_missing_user_agent(self, mock_request):
+        detector = CopilotDetector()
+        assert detector.detect(mock_request) is False
+
+
+class TestDetectClient:
+    @pytest.mark.asyncio
+    async def test_successful_client_detection(self, mock_request):
+        detect_client = DetectClient()
+
+        async def get_json():
+            return {"messages": [{"content": "Cline"}]}
+
+        mock_request.json = get_json
+
+        @detect_client
+        async def test_endpoint(request: Request):
+            return request.state.detected_client
+
+        result = await test_endpoint(mock_request)
+        assert result == ClientType.CLINE
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_generic(self, mock_request):
+        detect_client = DetectClient()
+
+        async def get_json():
+            return {"messages": [{"content": "Unknown Client"}]}
+
+        mock_request.json = get_json
+
+        @detect_client
+        async def test_endpoint(request: Request):
+            return request.state.detected_client
+
+        result = await test_endpoint(mock_request)
+        assert result == ClientType.GENERIC
+
+    @pytest.mark.asyncio
+    async def test_error_handling(self, mock_request):
+        detect_client = DetectClient()
+
+        async def get_json():
+            raise Exception("Test error")
+
+        mock_request.json = get_json
+
+        @detect_client
+        async def test_endpoint(request: Request):
+            return request.state.detected_client
+
+        result = await test_endpoint(mock_request)
+        assert result == ClientType.GENERIC
+
+    @pytest.mark.asyncio
+    async def test_state_setting(self, mock_request):
+        detect_client = DetectClient()
+
+        async def get_json():
+            return {"messages": [{"content": "Kodu"}]}
+
+        mock_request.json = get_json
+
+        @detect_client
+        async def test_endpoint(request: Request):
+            assert hasattr(request.state, "detected_client")
+            return request.state.detected_client
+
+        result = await test_endpoint(mock_request)
+        assert result == ClientType.KODU

--- a/tests/pipeline/test_messages_block.py
+++ b/tests/pipeline/test_messages_block.py
@@ -1,10 +1,11 @@
 import pytest
 
+from codegate.clients.clients import ClientType
 from codegate.pipeline.base import PipelineStep
 
 
 @pytest.mark.parametrize(
-    "input, expected_output",
+    "input, expected_output, client_type",
     [
         # Test case: Consecutive user messages at the end
         (
@@ -16,6 +17,7 @@ from codegate.pipeline.base import PipelineStep
                 ]
             },
             ("Hello!\nHow are you?", 1),
+            ClientType.GENERIC,
         ),
         # Test case: Mixed roles at the end
         (
@@ -28,6 +30,7 @@ from codegate.pipeline.base import PipelineStep
                 ]
             },
             ("Hello!\nHow are you?", 0),
+            ClientType.GENERIC,
         ),
         # Test case: No user messages
         (
@@ -38,9 +41,10 @@ from codegate.pipeline.base import PipelineStep
                 ]
             },
             None,
+            ClientType.GENERIC,
         ),
         # Test case: Empty message list
-        ({"messages": []}, None),
+        ({"messages": []}, None, ClientType.GENERIC),
         # Test case: Consecutive user messages interrupted by system message
         (
             {
@@ -52,6 +56,7 @@ from codegate.pipeline.base import PipelineStep
                 ]
             },
             ("How are you?\nWhat's up?", 2),
+            ClientType.GENERIC,
         ),
         # Test case: aider
         (
@@ -116,6 +121,7 @@ if not github_token:
 evaluate this file""",  # noqa: E501
                 7,
             ),
+            ClientType.GENERIC,
         ),
         # Test case: open interpreter
         (
@@ -172,8 +178,9 @@ def hello():
         return "Hello, Mars! We have no token here"''',  # noqa: E501
                 1,
             ),
+            ClientType.OPEN_INTERPRETER,
         ),
     ],
 )
-def test_get_last_user_message_block(input, expected_output):
-    assert PipelineStep.get_last_user_message_block(input) == expected_output
+def test_get_last_user_message_block(input, expected_output, client_type):
+    assert PipelineStep.get_last_user_message_block(input, client_type) == expected_output


### PR DESCRIPTION
- **Add client detector interface** - Adds a decorator that can be added to the FastAPI handlers and detect the client from a fallback mechanism, by the user-agent, by a specific header or by a matching word in the messages. At the moment, the clients are represented as a simple enum, but in follow-up patches they will be represented by classes that can perform the changes by an interface providing callbacks from the pipeline or other places that need client-specific behaviour.
- **Use the client type when streaming the data to the client, not when executing completion** - We used to special-case ollama stream generation by passing the client type to the execute_completion. Instead, let's pass the client type to the place that needs special casing using the recently introduce client type enum.
- **Use the client type when instantiating and running provider pipelines** - Instead of detecting the client type again when the pipeline is being processed, let's pass the client type on instantiating the pipeline instance as a constant and replace the hardcoded client strings by just using the constants.
- **Remove get_tool_name_from_messages** - This was superseded by using the client enum.
- **Remove the is_copilot flag in favor of using the autodetected client** - In the copilot provider, we can hardcode the client type to copilot when instantiating the pipelines.
