### PR TITLE
Implement muxing routing cache

### DIFF
--- a/src/codegate/cli.py
+++ b/src/codegate/cli.py
@@ -21,6 +21,7 @@ from codegate.providers import crud as provendcrud
 from codegate.providers.copilot.provider import CopilotProvider
 from codegate.server import init_app
 from codegate.storage.utils import restore_storage_backup
+from codegate.workspaces import crud as wscrud
 
 
 class UvicornServer:
@@ -341,6 +342,8 @@ def serve(  # noqa: C901
 
         registry = app.provider_registry
         loop.run_until_complete(provendcrud.initialize_provider_endpoints(registry))
+        wsc = wscrud.WorkspaceCrud()
+        loop.run_until_complete(wsc.initialize_mux_registry())
 
         # Run the server
         try:

--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -20,7 +20,6 @@ from codegate.db.models import (
     GetPromptWithOutputsRow,
     GetWorkspaceByNameConditions,
     MuxRule,
-    MuxRuleProviderEndpoint,
     Output,
     Prompt,
     ProviderAuthMaterial,
@@ -791,26 +790,6 @@ class DbReader(DbCodeGate):
         conditions = {"workspace_id": workspace_id}
         muxes = await self._exec_select_conditions_to_pydantic(
             MuxRule, sql, conditions, should_raise=True
-        )
-        return muxes
-
-    async def get_muxes_with_provider_by_workspace(
-        self, workspace_id: str
-    ) -> List[MuxRuleProviderEndpoint]:
-        sql = text(
-            """
-            SELECT m.id, m.provider_endpoint_id, m.provider_model_name, m.workspace_id,
-            m.matcher_type, m.matcher_blob, m.priority, m.created_at, m.updated_at,
-            pe.provider_type, pe.endpoint, pe.auth_type, pe.auth_blob
-            FROM muxes m
-            INNER JOIN provider_endpoints pe ON pe.id = m.provider_endpoint_id
-            WHERE m.workspace_id = :workspace_id
-            ORDER BY priority ASC
-            """
-        )
-        conditions = {"workspace_id": workspace_id}
-        muxes = await self._exec_select_conditions_to_pydantic(
-            MuxRuleProviderEndpoint, sql, conditions, should_raise=True
         )
         return muxes
 

--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -711,6 +711,22 @@ class DbReader(DbCodeGate):
         )
         return provider[0] if provider else None
 
+    async def get_auth_material_by_provider_id(
+        self, provider_id: str
+    ) -> Optional[ProviderAuthMaterial]:
+        sql = text(
+            """
+            SELECT id as provider_endpoint_id, auth_type, auth_blob
+            FROM provider_endpoints
+            WHERE id = :provider_endpoint_id
+            """
+        )
+        conditions = {"provider_endpoint_id": provider_id}
+        auth_material = await self._exec_select_conditions_to_pydantic(
+            ProviderAuthMaterial, sql, conditions, should_raise=True
+        )
+        return auth_material[0] if auth_material else None
+
     async def get_provider_endpoints(self) -> List[ProviderEndpoint]:
         sql = text(
             """

--- a/src/codegate/db/models.py
+++ b/src/codegate/db/models.py
@@ -199,19 +199,3 @@ class MuxRule(BaseModel):
     priority: int
     created_at: Optional[datetime.datetime] = None
     updated_at: Optional[datetime.datetime] = None
-
-
-class MuxRuleProviderEndpoint(BaseModel):
-    id: str
-    provider_endpoint_id: str
-    provider_model_name: str
-    workspace_id: str
-    matcher_type: str
-    matcher_blob: str
-    priority: int
-    created_at: Optional[datetime.datetime] = None
-    updated_at: Optional[datetime.datetime] = None
-    provider_type: ProviderType
-    endpoint: str
-    auth_type: str
-    auth_blob: str

--- a/src/codegate/muxing/router.py
+++ b/src/codegate/muxing/router.py
@@ -3,7 +3,8 @@ import json
 import structlog
 from fastapi import APIRouter, HTTPException, Request
 
-from codegate.mux.adapter import BodyAdapter, ResponseAdapter
+from codegate.muxing import rulematcher
+from codegate.muxing.adapter import BodyAdapter, ResponseAdapter
 from codegate.providers.registry import ProviderRegistry
 from codegate.workspaces.crud import WorkspaceCrud
 
@@ -23,6 +24,7 @@ class MuxRouter:
         self._setup_routes()
         self._provider_registry = provider_registry
         self._response_adapter = ResponseAdapter()
+        self._mux_registry = rulematcher.get_muxing_rules_registry()
 
     @property
     def route_name(self) -> str:
@@ -54,26 +56,25 @@ class MuxRouter:
             data = json.loads(body)
 
             try:
-                active_ws_muxes = await self._ws_crud.get_active_workspace_muxes()
+                # TODO: For future releases we will have to idenify a thing_to_match
+                # and use our registry to get the correct muxes for the active workspace
+                model_route = self._mux_registry.get_match_for_active_workspace(thing_to_match=None)
             except Exception as e:
                 logger.error(f"Error getting active workspace muxes: {e}")
                 raise HTTPException(str(e))
 
-            # TODO: Implement the muxing logic here. For the moment we will assume
-            # that we have a single mux, i.e. a single destination provider.
-            if len(active_ws_muxes) == 0:
-                raise HTTPException(status_code=404, detail="No active workspace muxes found")
-            mux_and_provider = active_ws_muxes[0]
+            if not model_route:
+                raise HTTPException("No rule found for the active workspace", status_code=404)
 
             # Parse the input data and map it to the destination provider format
             rest_of_path = self._ensure_path_starts_with_slash(rest_of_path)
-            new_data = self._body_adapter.map_body_to_dest(mux_and_provider, data)
-            provider = self._provider_registry.get_provider(mux_and_provider.provider_type)
-            api_key = mux_and_provider.auth_blob
+            new_data = self._body_adapter.map_body_to_dest(model_route, data)
+            provider = self._provider_registry.get_provider(model_route.endpoint.provider_type)
+            api_key = model_route.auth_material.auth_blob
 
             # Send the request to the destination provider. It will run the pipeline
             response = await provider.process_request(new_data, api_key, rest_of_path)
             # Format the response to the client always using the OpenAI format
             return self._response_adapter.format_response_to_client(
-                response, mux_and_provider.provider_type
+                response, model_route.endpoint.provider_type
             )

--- a/src/codegate/muxing/router.py
+++ b/src/codegate/muxing/router.py
@@ -24,7 +24,6 @@ class MuxRouter:
         self._setup_routes()
         self._provider_registry = provider_registry
         self._response_adapter = ResponseAdapter()
-        self._mux_registry = rulematcher.get_muxing_rules_registry()
 
     @property
     def route_name(self) -> str:
@@ -55,10 +54,11 @@ class MuxRouter:
             body = await request.body()
             data = json.loads(body)
 
+            mux_registry = await rulematcher.get_muxing_rules_registry()
             try:
                 # TODO: For future releases we will have to idenify a thing_to_match
                 # and use our registry to get the correct muxes for the active workspace
-                model_route = self._mux_registry.get_match_for_active_workspace(thing_to_match=None)
+                model_route = await mux_registry.get_match_for_active_workspace(thing_to_match=None)
             except Exception as e:
                 logger.error(f"Error getting active workspace muxes: {e}")
                 raise HTTPException(str(e))

--- a/src/codegate/muxing/rulematcher.py
+++ b/src/codegate/muxing/rulematcher.py
@@ -1,0 +1,118 @@
+import copy
+from abc import ABC, abstractmethod
+from collections import UserDict
+from threading import Lock, RLock
+from typing import List, Optional
+
+from codegate.db import models as db_models
+
+_muxrules_sgtn = None
+
+_singleton_lock = Lock()
+
+
+def get_muxing_rules_registry():
+    """Returns a singleton instance of the muxing rules registry."""
+
+    global _muxrules_sgtn
+
+    if _muxrules_sgtn is None:
+        with _singleton_lock:
+            if _muxrules_sgtn is None:
+                _muxrules_sgtn = MuxingRulesinWorkspaces()
+
+    return _muxrules_sgtn
+
+
+class ModelRoute:
+    """A route for a model."""
+
+    def __init__(
+        self,
+        model: db_models.ProviderModel,
+        endpoint: db_models.ProviderEndpoint,
+        auth_material: db_models.ProviderAuthMaterial,
+    ):
+        self.model = model
+        self.endpoint = endpoint
+        self.auth_material = auth_material
+
+
+class MuxingRuleMatcher(ABC):
+    """Base class for matching muxing rules."""
+
+    def __init__(self, route: ModelRoute):
+        self._route = route
+
+    @abstractmethod
+    def match(self, thing_to_match) -> bool:
+        """Return True if the rule matches the thing_to_match."""
+        pass
+
+    def destination(self) -> ModelRoute:
+        """Return the destination of the rule."""
+
+        return self._route
+
+
+class MuxingMatcherFactory:
+    """Factory for creating muxing matchers."""
+
+    @staticmethod
+    def create(mux_rule: db_models.MuxRule, route: ModelRoute) -> MuxingRuleMatcher:
+        """Create a muxing matcher for the given endpoint and model."""
+
+        factory = {
+            "catch_all": CatchAllMuxingRuleMatcher,
+        }
+
+        try:
+            return factory[mux_rule.matcher_type](route)
+        except KeyError:
+            raise ValueError(f"Unknown matcher type: {mux_rule.matcher_type}")
+
+
+class CatchAllMuxingRuleMatcher(MuxingRuleMatcher):
+    """A catch all muxing rule matcher."""
+
+    def match(self, thing_to_match) -> bool:
+        return True
+
+
+class MuxingRulesinWorkspaces(UserDict):
+    """A thread safe dictionary to store the muxing rules in workspaces."""
+
+    def __init__(self):
+        super().__init__()
+        self._lock = RLock()
+        self._active_workspace = ""
+
+    def __getitem__(self, key: str) -> List[MuxingRuleMatcher]:
+        with self._lock:
+            # We return a copy so concurrent modifications don't affect the original
+            return copy.deepcopy(super().__getitem__(key))
+
+    def __setitem__(self, key: str, value: List[MuxingRuleMatcher]):
+        with self._lock:
+            super().__setitem__(key, value)
+
+    def __delitem__(self, key: str):
+        with self._lock:
+            super().__delitem__(key)
+
+    def set_active_workspace(self, workspace_id: str):
+        """Set the active workspace."""
+        self._active_workspace = workspace_id
+
+    def get_match_for_active_workspace(self, thing_to_match) -> Optional[ModelRoute]:
+        """Get the first match for the given thing_to_match."""
+
+        # We iterate over all the rules and return the first match
+        # Since we already do a deepcopy in __getitem__, we don't need to lock here
+        try:
+            for rule in self[self._active_workspace]:
+                if rule.match(thing_to_match):
+                    return rule.destination()
+            return None
+        except KeyError:
+            raise RuntimeError("No rules found for the active workspace")

--- a/src/codegate/muxing/rulematcher.py
+++ b/src/codegate/muxing/rulematcher.py
@@ -82,7 +82,7 @@ class CatchAllMuxingRuleMatcher(MuxingRuleMatcher):
 class MuxingRulesinWorkspaces(UserDict):
     """A thread safe dictionary to store the muxing rules in workspaces."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self._lock = RLock()
         self._active_workspace = ""
@@ -92,17 +92,17 @@ class MuxingRulesinWorkspaces(UserDict):
             # We return a copy so concurrent modifications don't affect the original
             return copy.deepcopy(super().__getitem__(key))
 
-    def __setitem__(self, key: str, value: List[MuxingRuleMatcher]):
+    def __setitem__(self, key: str, value: List[MuxingRuleMatcher]) -> None:
         with self._lock:
             super().__setitem__(key, value)
 
-    def __delitem__(self, key: str):
+    def __delitem__(self, key: str) -> None:
         with self._lock:
             super().__delitem__(key)
 
-    def set_active_workspace(self, workspace_id: str):
+    def set_active_workspace(self, workspace_name: str) -> None:
         """Set the active workspace."""
-        self._active_workspace = workspace_id
+        self._active_workspace = workspace_name
 
     def get_match_for_active_workspace(self, thing_to_match) -> Optional[ModelRoute]:
         """Get the first match for the given thing_to_match."""

--- a/src/codegate/server.py
+++ b/src/codegate/server.py
@@ -11,7 +11,7 @@ from starlette.middleware.errors import ServerErrorMiddleware
 from codegate import __description__, __version__
 from codegate.api.v1 import v1
 from codegate.db.models import ProviderType
-from codegate.mux.router import MuxRouter
+from codegate.muxing.router import MuxRouter
 from codegate.pipeline.factory import PipelineFactory
 from codegate.providers.anthropic.provider import AnthropicProvider
 from codegate.providers.llamacpp.provider import LlamaCppProvider

--- a/src/codegate/workspaces/crud.py
+++ b/src/codegate/workspaces/crud.py
@@ -1,4 +1,3 @@
-import asyncio
 import datetime
 from typing import List, Optional, Tuple
 from uuid import uuid4 as uuid
@@ -12,6 +11,7 @@ from codegate.db.models import (
     WorkspaceRow,
     WorkspaceWithSessionInfo,
 )
+from codegate.muxing import rulematcher
 
 
 class WorkspaceCrudError(Exception):
@@ -38,8 +38,12 @@ RESERVED_WORKSPACE_KEYWORDS = [DEFAULT_WORKSPACE_NAME, "active", "archived"]
 
 class WorkspaceCrud:
 
-    def __init__(self):
+    def __init__(
+        self,
+        mux_registry: rulematcher.MuxingRulesinWorkspaces = rulematcher.get_muxing_rules_registry(),
+    ):
         self._db_reader = DbReader()
+        self._mux_registry = mux_registry
 
     async def add_workspace(self, new_workspace_name: str) -> WorkspaceRow:
         """
@@ -136,6 +140,9 @@ class WorkspaceCrud:
         session.last_update = datetime.datetime.now(datetime.timezone.utc)
         db_recorder = DbRecorder()
         await db_recorder.update_session(session)
+
+        # Ensure the mux registry is updated
+        self._mux_registry.set_active_workspace(workspace.id)
         return
 
     async def recover_workspace(self, workspace_name: str):
@@ -190,6 +197,9 @@ class WorkspaceCrud:
             _ = await db_recorder.soft_delete_workspace(selected_workspace)
         except Exception:
             raise WorkspaceCrudError(f"Error deleting workspace {workspace_name}")
+
+        # Remove the muxes from the registry
+        del self._mux_registry[workspace_name]
         return
 
     async def hard_delete_workspace(self, workspace_name: str):
@@ -260,6 +270,8 @@ class WorkspaceCrud:
 
     # Can't use type hints since the models are not yet defined
     async def set_muxes(self, workspace_name: str, muxes):
+        from codegate.api import v1_models
+
         # Verify if workspace exists
         workspace = await self._db_reader.get_workspace_by_name(workspace_name)
         if not workspace:
@@ -269,23 +281,19 @@ class WorkspaceCrud:
         db_recorder = DbRecorder()
         await db_recorder.delete_muxes_by_workspace(workspace.id)
 
-        tasks = set()
-
         # Add the new muxes
         priority = 0
 
+        muxes_with_routes: List[Tuple[v1_models.MuxRule, rulematcher.ModelRoute]] = []
+
         # Verify all models are valid
         for mux in muxes:
-            dbm = await self._db_reader.get_provider_model_by_provider_id_and_name(
-                mux.provider_id,
-                mux.model,
-            )
-            if not dbm:
-                raise WorkspaceCrudError(
-                    f"Model {mux.model} does not exist for provider {mux.provider_id}"
-                )
+            route = await self.get_routing_for_mux(mux)
+            muxes_with_routes.append((mux, route))
 
-        for mux in muxes:
+        matchers: List[rulematcher.MuxingRuleMatcher] = []
+
+        for mux, route in muxes_with_routes:
             new_mux = MuxRule(
                 id=str(uuid()),
                 provider_endpoint_id=mux.provider_id,
@@ -295,11 +303,95 @@ class WorkspaceCrud:
                 matcher_blob=mux.matcher if mux.matcher else "",
                 priority=priority,
             )
-            tasks.add(db_recorder.add_mux(new_mux))
+            dbmux = await db_recorder.add_mux(new_mux)
+
+            matchers.append(rulematcher.MuxingMatcherFactory.create(dbmux, route))
 
             priority += 1
 
-        await asyncio.gather(*tasks)
+        # Set routing list for the workspace
+        self._mux_registry[workspace_name] = matchers
+
+    async def get_routing_for_mux(self, mux) -> rulematcher.ModelRoute:
+        """Get the routing for a mux
+
+        Note that this particular mux object is the API model, not the database model.
+        It's only not annotated because of a circular import issue.
+        """
+        dbprov = await self._db_reader.get_provider_endpoint_by_id(mux.provider_id)
+        if not dbprov:
+            raise WorkspaceCrudError(f"Provider {mux.provider_id} does not exist")
+
+        dbm = await self._db_reader.get_provider_model_by_provider_id_and_name(
+            mux.provider_id,
+            mux.model,
+        )
+        if not dbm:
+            raise WorkspaceCrudError(
+                f"Model {mux.model} does not exist for provider {mux.provider_id}"
+            )
+        dbauth = await self._db_reader.get_auth_material_by_provider_id(mux.provider_id)
+        if not dbauth:
+            raise WorkspaceCrudError(f"Auth material for provider {mux.provider_id} does not exist")
+
+        return rulematcher.ModelRoute(
+            provider=dbprov,
+            model=dbm,
+            auth=dbauth,
+        )
+
+    async def get_routing_for_db_mux(self, mux: MuxRule) -> rulematcher.ModelRoute:
+        """Get the routing for a mux
+
+        Note that this particular mux object is the database model, not the API model.
+        It's only not annotated because of a circular import issue.
+        """
+        dbprov = await self._db_reader.get_provider_endpoint_by_id(mux.provider_endpoint_id)
+        if not dbprov:
+            raise WorkspaceCrudError(f"Provider {mux.provider_endpoint_id} does not exist")
+
+        dbm = await self._db_reader.get_provider_model_by_provider_id_and_name(
+            mux.provider_endpoint_id,
+            mux.provider_model_name,
+        )
+        if not dbm:
+            raise WorkspaceCrudError(
+                f"Model {mux.provider_model_name} does not "
+                "exist for provider {mux.provider_endpoint_id}"
+            )
+        dbauth = await self._db_reader.get_auth_material_by_provider_id(mux.provider_endpoint_id)
+        if not dbauth:
+            raise WorkspaceCrudError(
+                f"Auth material for provider {mux.provider_endpoint_id} does not exist"
+            )
+
+        return rulematcher.ModelRoute(
+            model=dbm,
+            endpoint=dbprov,
+            auth_material=dbauth,
+        )
+
+    async def initialize_mux_registry(self):
+        """Initialize the mux registry with all workspaces in the database"""
+
+        active_ws = await self.get_active_workspace()
+        if active_ws:
+            self._mux_registry.set_active_workspace(active_ws.name)
+
+        # Get all workspaces
+        workspaces = await self.get_workspaces()
+
+        # For each workspace, get the muxes and set them in the registry
+        for ws in workspaces:
+            muxes = await self._db_reader.get_muxes_by_workspace(ws.id)
+
+            matchers: List[rulematcher.MuxingRuleMatcher] = []
+
+            for mux in muxes:
+                route = await self.get_routing_for_db_mux(mux)
+                matchers.append(rulematcher.MuxingMatcherFactory.create(mux, route))
+
+            self._mux_registry[ws.name] = matchers
 
     async def get_active_workspace_muxes(self) -> List[MuxRuleProviderEndpoint]:
         active_workspace = await self.get_active_workspace()

--- a/src/codegate/workspaces/crud.py
+++ b/src/codegate/workspaces/crud.py
@@ -386,6 +386,10 @@ class WorkspaceCrud:
         # Get all workspaces
         workspaces = await self.get_workspaces()
 
+        # TODO: Get workspaces from _mux_registry and
+        # Remove the ones that are not in the workspaces list
+        # We just got from the db.
+
         # For each workspace, get the muxes and set them in the registry
         for ws in workspaces:
             muxes = await self._db_reader.get_muxes_by_workspace(ws.id)

--- a/src/codegate/workspaces/crud.py
+++ b/src/codegate/workspaces/crud.py
@@ -378,6 +378,11 @@ class WorkspaceCrud:
         if active_ws:
             self._mux_registry.set_active_workspace(active_ws.name)
 
+        return self.repopulate_mux_cache()
+
+    async def repopulate_mux_cache(self):
+        """Repopulate the mux cache with all muxes in the database"""
+
         # Get all workspaces
         workspaces = await self.get_workspaces()
 


### PR DESCRIPTION
This allows us to have a parsed and in-memory representation of the
routing rule engine. The intent is to reduce calls to the database.

This is more expensive to maintain since we need to refresh the cache on
every operation pertaining to models, endpoints, workspaces, and muxes themselves.

Finally, this implements the interface for matchers; Currently we only have one
"catch all" matcher, but this will change in the future.

Closes #786 

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com> and Alejandro Ponce de León <aponcedeleonch@stacklok.com>
