### PR TITLE
Enable the integration tests for llamacpp

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,6 +51,11 @@ jobs:
           echo "Loaded image:"
           docker images
 
+      - name: Download the Qwen2.5-Coder-0.5B-Instruct-GGUF model
+        run: |
+          # This is needed for the llamacpp integration tests
+          wget -P ./codegate_volume/models https://huggingface.co/Qwen/Qwen2.5-Coder-0.5B-Instruct-GGUF/resolve/main/qwen2.5-coder-0.5b-instruct-q5_k_m.gguf
+
       - name: Run container from the loaded image
         run: |
           # Get the image name
@@ -232,6 +237,12 @@ jobs:
       - name: Run integration tests - vllm
         env:
           CODEGATE_PROVIDERS: "vllm"
+        run: |
+          poetry run python tests/integration/integration_tests.py
+
+      - name: Run integration tests - llamacpp
+        env:
+          CODEGATE_PROVIDERS: "llamacpp"
         run: |
           poetry run python tests/integration/integration_tests.py
 

--- a/src/codegate/providers/llamacpp/completion_handler.py
+++ b/src/codegate/providers/llamacpp/completion_handler.py
@@ -59,19 +59,24 @@ class LlamaCppCompletionHandler(BaseCompletionHandler):
         """
         model_path = f"{Config.get_config().model_base_path}/{request['model']}.gguf"
 
+        # Create a copy of the request dict and remove stream_options
+        # Reason - Request error as JSON: {'error': "Llama.create_completion() got an unexpected keyword argument 'stream_options'"}
+        request_dict = dict(request)
+        request_dict.pop("stream_options", None)
+
         if is_fim_request:
             response = await self.inference_engine.complete(
                 model_path,
                 Config.get_config().chat_model_n_ctx,
                 Config.get_config().chat_model_n_gpu_layers,
-                **request,
+                **request_dict,
             )
         else:
             response = await self.inference_engine.chat(
                 model_path,
                 Config.get_config().chat_model_n_ctx,
                 Config.get_config().chat_model_n_gpu_layers,
-                **request,
+                **request_dict,
             )
 
         return convert_to_async_iterator(response) if stream else response

--- a/src/codegate/providers/llamacpp/completion_handler.py
+++ b/src/codegate/providers/llamacpp/completion_handler.py
@@ -60,7 +60,8 @@ class LlamaCppCompletionHandler(BaseCompletionHandler):
         model_path = f"{Config.get_config().model_base_path}/{request['model']}.gguf"
 
         # Create a copy of the request dict and remove stream_options
-        # Reason - Request error as JSON: {'error': "Llama.create_completion() got an unexpected keyword argument 'stream_options'"}
+        # Reason - Request error as JSON:
+        # {'error': "Llama.create_completion() got an unexpected keyword argument 'stream_options'"}
         request_dict = dict(request)
         request_dict.pop("stream_options", None)
 

--- a/tests/integration/testcases.yaml
+++ b/tests/integration/testcases.yaml
@@ -6,6 +6,7 @@ headers:
   ollama:
     Content-Type: application/json
   llamacpp:
+    Content-Type: application/json
   anthropic:
     x-api-key: ENV_ANTHROPIC_KEY
   copilot:
@@ -68,7 +69,7 @@ testcases:
               "role":"user"
             }
         ],
-        "model":"qwen2.5-coder-1.5b-instruct-q5_k_m",
+        "model":"qwen2.5-coder-0.5b-instruct-q5_k_m",
         "stream":true,
         "temperature":0
       }
@@ -81,7 +82,7 @@ testcases:
     url: http://127.0.0.1:8989/llamacpp/completions
     data: |
       {
-        "model": "qwen2.5-coder-1.5b-instruct-q5_k_m",
+        "model": "qwen2.5-coder-0.5b-instruct-q5_k_m",
         "max_tokens": 4096,
         "temperature": 0,
         "stream": true,

--- a/tests/integration/testcases.yaml
+++ b/tests/integration/testcases.yaml
@@ -86,14 +86,11 @@ testcases:
         "max_tokens": 4096,
         "temperature": 0,
         "stream": true,
-        "stop": ["<|endoftext|>", "<|fim_prefix|>", "<|fim_middle|>", "<|fim_suffix|>", "<|fim_pad|>", "<|repo_name|>", "<|file_sep|>", "<|im_start|>", "<|im_end|>", "/src/", "#- coding: utf-8", "```"],
-        "prompt":"<|fim_prefix|>\n# codegate/test.py\nimport invokehttp\nimport requests\n\nkey = \"mysecret-key\"\n\ndef call_api():\n    <|fim_suffix|>\n\n\ndata = {'key1': 'test1', 'key2': 'test2'}\nresponse = call_api('http://localhost:8080', method='post', data='data')\n<|fim_middle|>"
+        "stop": ["<|endoftext|>", "<|fim_prefix|>", "<|fim_middle|>", "<|fim_suffix|>", "<|fim_pad|>", "<|repo_name|>", "<|file_sep|>", "<|im_start|>", "<|im_end|>", "/src/", "#- coding: utf-8", "```", "def test"],
+        "prompt":"# Do not add comments\n<|fim_prefix|>\n# codegate/greet.py\ndef print_hello():\n    <|fim_suffix|>\n\n\nprint_hello()\n<|fim_middle|>"
       }
     likes: |
-      url = 'http://localhost:8080'
-      headers = {'Authorization': f'Bearer {key}'}
-      response = requests.get(url, headers=headers)
-      return response.json()
+      print("Hello, World!")
 
   openai_chat:
     name: OpenAI Chat


### PR DESCRIPTION
The following PR enables the integration tests for llamacpp.

Details:
* Uses the `qwen2.5-coder-0.5b-instruct-q5_k_m` model
* Simplified the fim test case as using a simpler model was not responding correctly with the previous prompt and stop conditions (it was adding test functions, asserts, etc)
* Fixes an issue where the `stream_options` object was not recognised by llama (fixed it by removing it, let me know if this was not correct)
* Updates the integration_tests.py script to parse the response correctly (it was failing before)

Fixes: https://github.com/stacklok/codegate/issues/840