### PR TITLE
fix: be more flexible when interpreting codegate version

### DIFF
--- a/src/codegate/pipeline/cli/cli.py
+++ b/src/codegate/pipeline/cli/cli.py
@@ -80,7 +80,11 @@ def _get_cli_from_open_interpreter(last_user_message_str: str) -> Optional[re.Ma
         codegate_regex = re.compile(r"^codegate\s*(.*?)\s*$", re.IGNORECASE)
         match = codegate_regex.match(last_user_block)
         return match
-    return None
+    else:
+        # try to just get from the regex
+        codegate_regex = re.compile(r"^codegate\s*(.*?)\s*$", re.IGNORECASE)
+        match = codegate_regex.match(last_user_message_str)
+        return match
 
 
 class CodegateCli(PipelineStep):


### PR DESCRIPTION
Different combinations of open interpreter send the user message in different formats, accomodate to it