### PR TITLE
Support llamacpp provider in muxing

### DIFF
--- a/src/codegate/config.py
+++ b/src/codegate/config.py
@@ -21,6 +21,7 @@ DEFAULT_PROVIDER_URLS = {
     "vllm": "http://localhost:8000",  # Base URL without /v1 path
     "ollama": "http://localhost:11434",  # Default Ollama server URL
     "lm_studio": "http://localhost:1234",
+    "llamacpp": "./codegate_volume/models",  # Default LlamaCpp model path
 }
 
 

--- a/src/codegate/muxing/adapter.py
+++ b/src/codegate/muxing/adapter.py
@@ -104,6 +104,8 @@ class StreamChunkFormatter:
             db_models.ProviderType.ollama: self._format_ollama,
             db_models.ProviderType.openai: self._format_openai,
             db_models.ProviderType.anthropic: self._format_antropic,
+            # Our Lllamacpp provider emits OpenAI chunks
+            db_models.ProviderType.llamacpp: self._format_openai,
         }
 
     def _format_ollama(self, chunk: str) -> str:

--- a/src/codegate/providers/crud/crud.py
+++ b/src/codegate/providers/crud/crud.py
@@ -365,6 +365,7 @@ def __provider_endpoint_from_cfg(
 
 
 def provider_default_endpoints(provider_type: str) -> str:
+    # TODO: These providers default endpoints should come from config.py
     defaults = {
         "openai": "https://api.openai.com",
         "anthropic": "https://api.anthropic.com",

--- a/src/codegate/providers/llamacpp/completion_handler.py
+++ b/src/codegate/providers/llamacpp/completion_handler.py
@@ -57,13 +57,16 @@ class LlamaCppCompletionHandler(BaseCompletionHandler):
         """
         Execute the completion request with inference engine API
         """
-        model_path = f"{Config.get_config().model_base_path}/{request['model']}.gguf"
+        model_path = f"{request['base_url']}/{request['model']}.gguf"
 
         # Create a copy of the request dict and remove stream_options
         # Reason - Request error as JSON:
         # {'error': "Llama.create_completion() got an unexpected keyword argument 'stream_options'"}
         request_dict = dict(request)
         request_dict.pop("stream_options", None)
+        # Remove base_url from the request dict. We use this field as a standard across
+        # all providers to specify the base URL of the model.
+        request_dict.pop("base_url", None)
 
         if is_fim_request:
             response = await self.inference_engine.complete(


### PR DESCRIPTION
Closes: #883

There were a couple of nits that prevented support for llamacpp:
1. The `models` method was not implemented in the provider
2. A way of specifying the model outside `CompletionHandler`

These PR takes care of both