### PR TITLE
Add retry mechanism for starting the ollama container

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -138,47 +138,92 @@ jobs:
 
       - name: Run the Ollama container (ollama-only)
         if: ${{ matrix.test-provider == 'ollama' }} # This is only needed for Ollama
+        timeout-minutes: 15
+        env:
+          MAX_RETRIES: 3
         run: |
-          docker run -d -v ollama:/root/.ollama --network host --name ollama ollama/ollama
-          docker ps -f name=ollama
-          echo "Loop until the endpoint responds successfully"
-          while ! curl --silent --fail --get "http://localhost:11434" >/dev/null; do
-            echo "Ollama not available yet. Retrying in 2 seconds..."
-            sleep 2
-          done
-          echo "Ollama is now available!"
-
-          # Run the model
-          docker exec -d ollama ollama run qwen2.5-coder:0.5b
-
-          echo "Waiting for model to be ready..."
-          while true; do
-            # Try to make a test query to the model
+          function check_model_ready() {
             response=$(curl -s http://localhost:11434/api/generate -d '{
               "model": "qwen2.5-coder:0.5b",
               "prompt": "Why is the sky blue?",
               "stream": false
             }' 2>&1)
 
-            # Check if the response contains an error
-            if echo "$response" | grep -q "error"; then
-              echo "Model not ready yet. Retrying in 5 seconds..."
+            if ! echo "$response" | grep -q "error"; then
+              return 0  # Success
+            fi
+            return 1  # Not ready/error
+          }
+
+          function cleanup_container() {
+            docker stop ollama >/dev/null 2>&1 || true
+            docker rm ollama >/dev/null 2>&1 || true
+            sleep 2
+          }
+
+          retry_count=0
+          while [ $retry_count -lt $MAX_RETRIES ]; do
+            # Cleanup any existing container
+            cleanup_container
+
+            echo "Starting Ollama container (Attempt $(($retry_count + 1))/$MAX_RETRIES)"
+            docker run -d -v ollama:/root/.ollama --network host --name ollama ollama/ollama
+
+            # Wait for endpoint to be available
+            endpoint_wait=0
+            while [ $endpoint_wait -lt 30 ]; do
+              if curl --silent --fail --get "http://localhost:11434" >/dev/null; then
+                echo "Ollama endpoint is available"
+                break
+              fi
+              sleep 2
+              endpoint_wait=$((endpoint_wait + 1))
+            done
+
+            if [ $endpoint_wait -eq 30 ]; then
+              echo "Endpoint never became available, retrying..."
+              retry_count=$((retry_count + 1))
+              continue
+            fi
+
+            echo "Starting model download/initialization..."
+            docker exec -d ollama ollama run qwen2.5-coder:0.5b
+
+            # Monitor container and model status
+            monitor_count=0
+            while [ $monitor_count -lt 60 ]; do  # 5 minute timeout per attempt
+              # Check if container is still running
+              if ! docker ps | grep -q ollama; then
+                echo "Container crashed, logs:"
+                docker logs ollama
+                retry_count=$((retry_count + 1))
+                break
+              fi
+
+              # Check if model is ready
+              if check_model_ready; then
+                echo "Model is ready!"
+                exit 0  # Success!
+              fi
+
+              echo "Model not ready yet. Waiting... ($(($monitor_count + 1))/60)"
               sleep 5
-            else
-              echo "Model is ready!"
-              break
+              monitor_count=$((monitor_count + 1))
+            done
+
+            if [ $monitor_count -eq 60 ]; then
+              echo "Timeout waiting for model, container logs:"
+              docker logs ollama
+              retry_count=$((retry_count + 1))
             fi
           done
 
-          # Verify the Ollama API is working
-          curl http://localhost:11434/api/generate -d '{
-            "model": "qwen2.5-coder:0.5b",
-            "prompt": "Why is the sky blue?",
-            "stream": false
-          }'
+          echo "Failed after $MAX_RETRIES attempts"
+          exit 1
 
       - name: Build and run the vllm container (vllm-only)
         if: ${{ matrix.test-provider == 'vllm' }} # This is only needed for VLLM
+        timeout-minutes: 10
         run: |
           # We clone the VLLM repo and build the container because the CPU-mode container is not published
           git clone https://github.com/vllm-project/vllm.git


### PR DESCRIPTION
**The following PR:**
* Fixes a flakiness in the ollama test where the ollama container was crashing while downloading the model
* Adds a retry mechanism for starting the ollama container
* Adds fixed timeouts for 2 of the steps that loop waiting for the service to come available so we don't accidentally consume lots of action time

Validated this by starting a workflow running 32 integration tests in parallel where the crashed happened and the retry handled it - https://github.com/stacklok/codegate/actions/runs/13132206637/job/36639688048

**Logs of the issue:** 

```bash
Run # Initialize counters and limits
Starting Ollama container (Attempt 1/3)
Unable to find image 'ollama/ollama:latest' locally
latest: Pulling from ollama/ollama
6414378b6477: Pulling fs layer
ce386310af0b: Pulling fs layer
434f39e9aa8e: Pulling fs layer
bbc15f5291c8: Pulling fs layer
bbc15f5291c8: Waiting
ce386310af0b: Verifying Checksum
ce386310af0b: Download complete
434f39e9aa8e: Verifying Checksum
434f39e9aa8e: Download complete
6414378b6477: Download complete
6414378b6477: Pull complete
ce386310af0b: Pull complete
434f39e9aa8e: Pull complete
bbc15f5291c8: Verifying Checksum
bbc15f5291c8: Download complete
bbc15f5291c8: Pull complete
Digest: sha256:7e672211886f8bd4448a98ed577e26c816b9e8b052[112](https://github.com/stacklok/codegate/actions/runs/13132206637/job/36639703989#step:15:113)860564afaa2c105800e
Status: Downloaded newer image for ollama/ollama:latest
55d638f78d6b2ac68292df8a3dbbc04414ae0821df18739613a7885becc0171d
Ollama endpoint is available
Starting model download/initialization...
Model not ready yet. Waiting... (1/60)
Container crashed, logs:
2025/02/04 09:26:11 routes.go:1187: INFO server config env="map[CUDA_VISIBLE_DEVICES: GPU_DEVICE_ORDINAL: HIP_VISIBLE_DEVICES: HSA_OVERRIDE_GFX_VERSION: HTTPS_PROXY: HTTP_PROXY: NO_PROXY: OLLAMA_DEBUG:false OLLAMA_FLASH_ATTENTION:false OLLAMA_GPU_OVERHEAD:0 OLLAMA_HOST:http://0.0.0.0:[114](https://github.com/stacklok/codegate/actions/runs/13132206637/job/36639703989#step:15:115)34 OLLAMA_INTEL_GPU:false OLLAMA_KEEP_ALIVE:5m0s OLLAMA_KV_CACHE_TYPE: OLLAMA_LLM_LIBRARY: OLLAMA_LOAD_TIMEOUT:5m0s OLLAMA_MAX_LOADED_MODELS:0 OLLAMA_MAX_QUEUE:512 OLLAMA_MODELS:/root/.ollama/models OLLAMA_MULTIUSER_CACHE:false OLLAMA_NOHISTORY:false OLLAMA_NOPRUNE:false OLLAMA_NUM_PARALLEL:0 OLLAMA_ORIGINS:[http://localhost https://localhost http://localhost:* https://localhost:* http://127.0.0.1 https://127.0.0.1 http://127.0.0.1:* https://127.0.0.1:* http://0.0.0.0 https://0.0.0.0 http://0.0.0.0:* https://0.0.0.0:* app://* file://* tauri://* vscode-webview://*] OLLAMA_SCHED_SPREAD:false ROCR_VISIBLE_DEVICES: http_proxy: https_proxy: no_proxy:]"
Couldn't find '/root/.ollama/id_ed25519'. Generating new private key.
time=2025-02-04T09:26:11.550Z level=INFO source=images.go:432 msg="total blobs: 0"
time=2025-02-04T09:26:11.550Z level=INFO source=images.go:439 msg="total unused blobs removed: 0"
time=2025-02-04T09:26:11.550Z level=INFO source=routes.go:[123](https://github.com/stacklok/codegate/actions/runs/13132206637/job/36639703989#step:15:124)8 msg="Listening on [::]:11434 (version 0.5.7-0-ga420a45-dirty)"
time=2025-02-04T09:26:11.551Z level=INFO source=routes.go:1267 msg="Dynamic LLM libraries" runners="[cuda_v12_avx cpu cpu_avx cpu_avx2 cuda_v11_avx]"
time=2025-02-04T09:26:11.551Z level=INFO source=gpu.go:226 msg="looking for compatible GPUs"
time=2025-02-04T09:26:11.553Z level=INFO source=gpu.go:392 msg="no compatible GPUs were discovered"
time=2025-02-04T09:26:11.553Z level=INFO source=types.go:131 msg="inference compute" id=0 library=cpu variant=avx2 compute="" driver=0.0 name="" total="15.6 GiB" available="14.4 GiB"
time=2025-02-04T09:26:14.207Z level=INFO source=download.go:175 msg="downloading 828125e28bf4 in 6 100 MB part(s)"
panic: runtime error: index out of range [0] with length 0

goroutine 51 [running]:
github.com/ollama/ollama/server.(*blobDownload).Prepare(0xc0004c25b0, {0x55809fe75580, 0xc000520690}, 0xc0003923f0, 0xc000090540)
	github.com/ollama/ollama/server/download.go:175 +0x539
github.com/ollama/ollama/server.downloadBlob({0x55809fe75580, 0xc000520690}, {{{0x55809fa39269, 0x5}, {0x55809fa4d641, 0x12}, {0x55809fa41d67, 0x7}, {0xc0005b8360, 0xd}, ...}, ...})
	github.com/ollama/ollama/server/download.go:489 +0x4da
github.com/ollama/ollama/server.PullModel({0x55809fe75580, 0xc000520690}, {0xc0005b8360, 0x12}, 0xc000090540, 0xc000[124](https://github.com/stacklok/codegate/actions/runs/13132206637/job/36639703989#step:15:125)d10)
	github.com/ollama/ollama/server/images.go:564 +0x771
github.com/ollama/ollama/server.(*Server).PullHandler.func1()
	github.com/ollama/ollama/server/routes.go:594 +0x197
created by github.com/ollama/ollama/server.(*Server).PullHandler in goroutine 12
	github.com/ollama/ollama/server/routes.go:581 +0x691
Your new public key is: 

ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOd0rIz6VSyu/JlydE4NhnG/IqZPOrtzUkxt46guh9VA

Warning: g] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.

Warning: g] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:	export GIN_MODE=release
 - using code:	gin.SetMode(gin.ReleaseMode)

[GIN-debug] POST   /api/pull                 --> github.com/ollama/ollama/server.(*Server).PullHandler-fm (5 handlers)
[GIN-debug] POST   /api/generate             --> github.com/ollama/ollama/server.(*Server).GenerateHandler-fm (5 handlers)
[GIN-debug] POST   /api/chat                 --> github.com/ollama/ollama/server.(*Server).ChatHandler-fm (5 handlers)
[GIN-debug] POST   /api/embed                --> github.com/ollama/ollama/server.(*Server).EmbedHandler-fm (5 handlers)
[GIN-debug] POST   /api/embeddings           --> github.com/ollama/ollama/server.(*Server).EmbeddingsHandler-fm (5 handlers)
[GIN-debug] POST   /api/create               --> github.com/ollama/ollama/server.(*Server).CreateHandler-fm (5 handlers)
[GIN-debug] POST   /api/push                 --> github.com/ollama/ollama/server.(*Server).PushHandler-fm (5 handlers)
[GIN-debug] POST   /api/copy                 --> github.com/ollama/ollama/server.(*Server).CopyHandler-fm (5 handlers)
[GIN-debug] DELETE /api/delete               --> github.com/ollama/ollama/server.(*Server).DeleteHandler-fm (5 handlers)
[GIN-debug] POST   /api/show                 --> github.com/ollama/ollama/server.(*Server).ShowHandler-fm (5 handlers)
[GIN-debug] POST   /api/blobs/:digest        --> github.com/ollama/ollama/server.(*Server).CreateBlobHandler-fm (5 handlers)
[GIN-debug] HEAD   /api/blobs/:digest        --> github.com/ollama/ollama/server.(*Server).HeadBlobHandler-fm (5 handlers)
[GIN-debug] GET    /api/ps                   --> github.com/ollama/ollama/server.(*Server).PsHandler-fm (5 handlers)
[GIN-debug] POST   /v1/chat/completions      --> github.com/ollama/ollama/server.(*Server).ChatHandler-fm (6 handlers)
[GIN-debug] POST   /v1/completions           --> github.com/ollama/ollama/server.(*Server).GenerateHandler-fm (6 handlers)
[GIN-debug] POST   /v1/embeddings            --> github.com/ollama/ollama/server.(*Server).EmbedHandler-fm (6 handlers)
[GIN-debug] GET    /v1/models                --> github.com/ollama/ollama/server.(*Server).ListHandler-fm (6 handlers)
[GIN-debug] GET    /v1/models/:model         --> github.com/ollama/ollama/server.(*Server).ShowHandler-fm (6 handlers)
[GIN-debug] GET    /                         --> github.com/ollama/ollama/server.(*Server).GenerateRoutes.func1 (5 handlers)
[GIN-debug] GET    /api/tags                 --> github.com/ollama/ollama/server.(*Server).ListHandler-fm (5 handlers)
[GIN-debug] GET    /api/version              --> github.com/ollama/ollama/server.(*Server).GenerateRoutes.func2 (5 handlers)
[GIN-debug] HEAD   /                         --> github.com/ollama/ollama/server.(*Server).GenerateRoutes.func1 (5 handlers)
[GIN-debug] HEAD   /api/tags                 --> github.com/ollama/ollama/server.(*Server).ListHandler-fm (5 handlers)
[GIN-debug] HEAD   /api/version              --> github.com/ollama/ollama/server.(*Server).GenerateRoutes.func2 (5 handlers)
[GIN] 2025/02/04 - 09:26:13 | 200 |      40.856µs |             ::1 | GET      "/"
[GIN] 2025/02/04 - 09:26:13 | 200 |      56.145µs |       [127](https://github.com/stacklok/codegate/actions/runs/13132206637/job/36639703989#step:15:128).0.0.1 | HEAD     "/"
[GIN] 2025/02/04 - 09:26:13 | 404 |       268.1µs |       127.0.0.1 | POST     "/api/show"
[GIN] 2025/02/04 - 09:26:13 | 404 |     158.587µs |             ::1 | POST     "/api/generate"
[GIN] 2025/02/04 - 09:26:16 | 200 |  2.813433499s |       127.0.0.1 | POST     "/api/pull"
Starting Ollama container (Attempt 2/3)
190a042d6c6c0b9edcff59307d48fdf0534fc77b8eebe1b434efaa043b8c02f2
Ollama endpoint is available
Starting model download/initialization...
Model not ready yet. Waiting... (1/60)
Model not ready yet. Waiting... (2/60)
Model is ready!
```