### PR TITLE
Remove CodeSnippetExtractor step

### DIFF
--- a/src/codegate/pipeline/base.py
+++ b/src/codegate/pipeline/base.py
@@ -71,7 +71,6 @@ class PipelineSensitiveData:
 
 @dataclass
 class PipelineContext:
-    code_snippets: List[CodeSnippet] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
     sensitive: Optional[PipelineSensitiveData] = field(default_factory=lambda: None)
     alerts_raised: List[Alert] = field(default_factory=list)
@@ -82,12 +81,6 @@ class PipelineContext:
     bad_packages_found: bool = False
     secrets_found: bool = False
     client: ClientType = ClientType.GENERIC
-
-    def add_code_snippet(self, snippet: CodeSnippet):
-        self.code_snippets.append(snippet)
-
-    def get_snippets_by_language(self, language: str) -> List[CodeSnippet]:
-        return [s for s in self.code_snippets if s.language.lower() == language.lower()]
 
     def add_alert(
         self,

--- a/src/codegate/pipeline/factory.py
+++ b/src/codegate/pipeline/factory.py
@@ -5,7 +5,6 @@ from codegate.config import Config
 from codegate.pipeline.base import PipelineStep, SequentialPipelineProcessor
 from codegate.pipeline.cli.cli import CodegateCli
 from codegate.pipeline.codegate_context_retriever.codegate import CodegateContextRetriever
-from codegate.pipeline.extract_snippets.extract_snippets import CodeSnippetExtractor
 from codegate.pipeline.extract_snippets.output import CodeCommentStep
 from codegate.pipeline.output import OutputPipelineProcessor, OutputPipelineStep
 from codegate.pipeline.secrets.manager import SecretsManager
@@ -29,7 +28,6 @@ class PipelineFactory:
             # later steps
             CodegateSecrets(),
             CodegateCli(),
-            CodeSnippetExtractor(),
             CodegateContextRetriever(),
             SystemPrompt(Config.get_config().prompts.default_chat),
         ]

--- a/tests/pipeline/extract_snippets/test_extract_snippets.py
+++ b/tests/pipeline/extract_snippets/test_extract_snippets.py
@@ -1,11 +1,9 @@
 from typing import List, NamedTuple
 
 import pytest
-from litellm.types.llms.openai import ChatCompletionRequest
 
-from codegate.pipeline.base import CodeSnippet, PipelineContext
+from codegate.pipeline.base import CodeSnippet
 from codegate.pipeline.extract_snippets.extract_snippets import (
-    CodeSnippetExtractor,
     ecosystem_from_filepath,
     extract_snippets,
 )
@@ -186,81 +184,3 @@ def test_valid_extensions(filepath, expected):
 )
 def test_no_or_unknown_extensions(filepath):
     assert ecosystem_from_filepath(filepath) is None
-
-
-@pytest.mark.asyncio
-async def test_code_snippet_extractor():
-    # Create a mock ChatCompletionRequest with a code snippet in the message
-    mock_request = {
-        "messages": [
-            {
-                "role": "user",
-                "content": """
-                Here's a Python snippet:
-                ```main.py
-                def hello():
-                    print("Hello, world!")
-                ```
-                """,
-            }
-        ]
-    }
-
-    # Create a pipeline context
-    context = PipelineContext()
-
-    # Instantiate the extractor
-    extractor = CodeSnippetExtractor()
-
-    # Process the request
-    result = await extractor.process(ChatCompletionRequest(**mock_request), context)
-
-    # Assertions
-    assert result.context is not None
-    assert len(result.context.code_snippets) == 1
-
-    # Verify the extracted snippet
-    snippet = result.context.code_snippets[0]
-    assert snippet.language == "python"
-    assert snippet.filepath == "main.py"
-    assert 'print("Hello, world!")' in snippet.code
-
-
-@pytest.mark.asyncio
-async def test_code_snippet_extractor_no_snippets():
-    # Create a mock ChatCompletionRequest without code snippets
-    mock_request = {
-        "messages": [{"role": "user", "content": "Just a plain text message with no code"}]
-    }
-
-    # Create a pipeline context
-    context = PipelineContext()
-
-    # Instantiate the extractor
-    extractor = CodeSnippetExtractor()
-
-    # Process the request
-    result = await extractor.process(ChatCompletionRequest(**mock_request), context)
-
-    # Assertions
-    assert result.context is not None
-    assert len(result.context.code_snippets) == 0
-
-
-@pytest.mark.asyncio
-async def test_code_snippet_extractor_no_messages():
-    # Create a mock ChatCompletionRequest with no messages
-    mock_request = {}
-
-    # Create a pipeline context
-    context = PipelineContext()
-
-    # Instantiate the extractor
-    extractor = CodeSnippetExtractor()
-
-    # Process the request
-    result = await extractor.process(ChatCompletionRequest(**mock_request), context)
-
-    # Assertions
-    assert result.context is not None
-    assert len(result.context.code_snippets) == 0


### PR DESCRIPTION
The step itself was not being used nor the snippets added were used by any subsequent step. The code in `extract_snippets.py` it is being used by other steps. Keeping that code intact.