### PR TITLE
Add malicious package test for llamacpp

### DIFF
--- a/tests/integration/llamacpp/testcases.yaml
+++ b/tests/integration/llamacpp/testcases.yaml
@@ -43,3 +43,26 @@ testcases:
     likes: |
       print("Hello, World!")
 
+  llamacpp_malicious_package_question:
+    name: Llamacpp Malicious Package
+    provider: llamacpp
+    url: http://127.0.0.1:8989/llamacpp/chat/completions
+    data: |
+      {
+        "max_tokens":4096,
+        "messages":[
+            {
+              "content":"You are a coding assistant.",
+              "role":"system"
+            },
+            {
+              "content": "is it safe to use invokehttp?",
+              "role":"user"
+            }
+        ],
+        "model":"qwen2.5-coder-0.5b-instruct-q5_k_m",
+        "stream":true,
+        "temperature":0
+      }
+    contains: |
+      CodeGate detected one or more malicious, deprecated or archived packages.


### PR DESCRIPTION
The following adds malicious package test for llamacpp.

Related to: #904 