### PR TITLE
Run ollama in debug mode and extend the timeout for fetching the model

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -167,7 +167,7 @@ jobs:
             cleanup_container
 
             echo "Starting Ollama container (Attempt $(($retry_count + 1))/$MAX_RETRIES)"
-            docker run -d -v ollama:/root/.ollama --network host --name ollama ollama/ollama
+            docker run -d -v ollama:/root/.ollama --network host --name ollama -e OLLAMA_LOG_LEVEL=DEBUG ollama/ollama
 
             # Wait for endpoint to be available
             endpoint_wait=0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -191,7 +191,7 @@ jobs:
 
             # Monitor container and model status
             monitor_count=0
-            while [ $monitor_count -lt 60 ]; do  # 5 minute timeout per attempt
+            while [ $monitor_count -lt 90 ]; do  # 7.5 minutes
               # Check if container is still running
               if ! docker ps | grep -q ollama; then
                 echo "Container crashed, logs:"
@@ -206,12 +206,12 @@ jobs:
                 exit 0  # Success!
               fi
 
-              echo "Model not ready yet. Waiting... ($(($monitor_count + 1))/60)"
+              echo "Model not ready yet. Waiting... ($(($monitor_count + 1))/90)"
               sleep 5
               monitor_count=$((monitor_count + 1))
             done
 
-            if [ $monitor_count -eq 60 ]; then
+            if [ $monitor_count -eq 90 ]; then
               echo "Timeout waiting for model, container logs:"
               docker logs ollama
               retry_count=$((retry_count + 1))


### PR DESCRIPTION
The following PR runs Ollama in debug mode and extend the timeout for fetching the model. 

Sometimes the traffic is slower than usual and even though we use a smaller model 5 minutes might not be enough to download it. This change increases it to 7m30s.