### PR TITLE
Fix for non-non streaming clients

### DIFF
--- a/src/codegate/providers/formatting/input_pipeline.py
+++ b/src/codegate/providers/formatting/input_pipeline.py
@@ -61,7 +61,6 @@ def _create_model_response(
             model=model,
         )
 
-
 async def _convert_to_stream(
     content: str,
     step_name: str,


### PR DESCRIPTION
Fixes #799 that returned improper json for non-streaming clients. This fix corrects also ensures that the chat requests and responses are persisted properly for display in codegate admin UI.