### PR TITLE
Fix for non streaming clients

### DIFF
--- a/src/codegate/providers/formatting/input_pipeline.py
+++ b/src/codegate/providers/formatting/input_pipeline.py
@@ -61,7 +61,6 @@ def _create_model_response(
             model=model,
         )
 
-
 async def _convert_to_stream(
     content: str,
     step_name: str,

--- a/src/codegate/providers/formatting/input_pipeline.py
+++ b/src/codegate/providers/formatting/input_pipeline.py
@@ -2,7 +2,7 @@ import time
 from typing import AsyncIterator, Union
 
 from litellm import ModelResponse
-from litellm.types.utils import Delta, StreamingChoices
+from litellm.types.utils import Choices, Delta, Message, StreamingChoices
 
 from codegate.db.connection import DbRecorder
 from codegate.pipeline.base import PipelineContext, PipelineResponse
@@ -56,10 +56,16 @@ def _create_model_response(
     else:
         return ModelResponse(
             id=response_id,
-            choices=[{"text": content, "index": 0, "finish_reason": None}],
+            # choices=[{"text": content, "index": 0, "finish_reason": None}],
+            choices=[
+                Choices(
+                    message=Message(content=content, role="assistant"),
+                )
+            ],
             created=created,
             model=model,
         )
+
 
 async def _convert_to_stream(
     content: str,


### PR DESCRIPTION
Fixes #799  that returned improper json for non-streaming clients. This fix also corrects also ensures that the chat requests and responses are persisted properly for display in codegate admin UI.