### PR TITLE
Fix codegate version for continue with DeepSeek

### DIFF
--- a/src/codegate/clients/clients.py
+++ b/src/codegate/clients/clients.py
@@ -12,3 +12,4 @@ class ClientType(Enum):
     COPILOT = "copilot"  # Copilot client
     OPEN_INTERPRETER = "open_interpreter"  # Open Interpreter client
     AIDER = "aider"  # Aider client
+    CONTINUE = "continue"  # Continue client

--- a/src/codegate/clients/detector.py
+++ b/src/codegate/clients/detector.py
@@ -160,6 +160,24 @@ class OpenInterpreter(BaseClientDetector):
         return ClientType.OPEN_INTERPRETER
 
 
+class ContinueDetector(BaseClientDetector):
+    """
+    Detector for Continue client based on message content
+    """
+
+    def __init__(self):
+        super().__init__()
+        # This is a hack that really only detects Continue with DeepSeek
+        # we should get a header or user agent for this (upstream PR pending)
+        self.content_detector = ContentDetector(
+            "You are an AI programming assistant, utilizing the DeepSeek Coder model"
+        )
+
+    @property
+    def client_name(self) -> ClientType:
+        return ClientType.CONTINUE
+
+
 class CopilotDetector(BaseClientDetector):
     """
     Detector for Copilot client based on user agent
@@ -191,6 +209,7 @@ class DetectClient:
             KoduDetector(),
             OpenInterpreter(),
             CopilotDetector(),
+            ContinueDetector(),
         ]
 
     def __call__(self, func):

--- a/tests/clients/test_detector.py
+++ b/tests/clients/test_detector.py
@@ -10,6 +10,7 @@ from codegate.clients.detector import (
     BaseClientDetector,
     ClineDetector,
     ContentDetector,
+    ContinueDetector,
     CopilotDetector,
     DetectClient,
     HeaderDetector,
@@ -288,6 +289,79 @@ class TestCopilotDetector:
     @pytest.mark.asyncio
     async def test_missing_user_agent(self, mock_request):
         detector = CopilotDetector()
+        assert await detector.detect(mock_request) is False
+
+
+class TestContinueDetector:
+    @pytest.mark.asyncio
+    async def test_successful_detection_via_system_message(self, mock_request):
+        detector = ContinueDetector()
+
+        async def get_json():
+            return {
+                "system": "You are an AI programming assistant, utilizing the DeepSeek Coder model"
+            }
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is True
+        assert detector.client_name == ClientType.CONTINUE
+
+    @pytest.mark.asyncio
+    async def test_detection_in_message_content(self, mock_request):
+        detector = ContinueDetector()
+
+        async def get_json():
+            return {
+                "messages": [
+                    {
+                        "content": "You are an AI programming assistant, utilizing the DeepSeek Coder model"  # noqa
+                    }
+                ]
+            }
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is True
+
+    @pytest.mark.asyncio
+    async def test_failed_detection_with_partial_match(self, mock_request):
+        detector = ContinueDetector()
+
+        async def get_json():
+            return {"system": "You are an AI assistant"}
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is False
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_match_handling(self, mock_request):
+        detector = ContinueDetector()
+
+        async def get_json():
+            return {
+                "system": "you ARE an ai programming assistant, UTILIZING the deepseek coder MODEL"
+            }
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is False  # Should be case-sensitive
+
+    @pytest.mark.asyncio
+    async def test_empty_system_message(self, mock_request):
+        detector = ContinueDetector()
+
+        async def get_json():
+            return {"system": ""}
+
+        mock_request.json = get_json
+        assert await detector.detect(mock_request) is False
+
+    @pytest.mark.asyncio
+    async def test_malformed_system_field(self, mock_request):
+        detector = ContinueDetector()
+
+        async def get_json():
+            return {"system": {"nested": "You are an AI programming assistant"}}
+
+        mock_request.json = get_json
         assert await detector.detect(mock_request) is False
 
 


### PR DESCRIPTION
`continue version` didn't work with DeepSeek because for some reason
they enclose the user message in a sort of an envelope.

To make the change a little future-proof, we use the envelope to detect
Continue as client and then in the cli command try to extract from the
envelope, but fall back to the generic plain regex.

Fixes: #981
