### PR TITLE
Fix chat message parsing in Cline

### DIFF
--- a/src/codegate/extract_snippets/body_extractor.py
+++ b/src/codegate/extract_snippets/body_extractor.py
@@ -70,6 +70,25 @@ class ClineBodySnippetExtractor(BodyCodeSnippetExtractor):
     def __init__(self):
         self._snippet_extractor = ClineCodeSnippetExtractor()
 
+    def _extract_from_user_messages(self, data: dict) -> set[str]:
+        """
+        The method extracts the code snippets from the user messages in the data got from Cline.
+
+        It returns a set of filenames extracted from the code snippets.
+        """
+
+        filenames: List[str] = []
+        for msg in data.get("messages", []):
+            if msg.get("role", "") == "user":
+                msgs_content = msg.get("content", [])
+                for msg_content in msgs_content:
+                    if msg_content.get("type", "") == "text":
+                        extracted_snippets = self._snippet_extractor.extract_unique_snippets(
+                            msg_content.get("text")
+                        )
+                        filenames.extend(extracted_snippets.keys())
+        return set(filenames)
+
     def extract_unique_filenames(self, data: dict) -> set[str]:
         return self._extract_from_user_messages(data)
 

--- a/src/codegate/muxing/router.py
+++ b/src/codegate/muxing/router.py
@@ -52,7 +52,7 @@ class MuxRouter:
             return model_route
         except Exception as e:
             logger.error(f"Error getting active workspace muxes: {e}")
-            raise HTTPException(str(e), status_code=404)
+            raise HTTPException(detail=str(e), status_code=404)
 
     def _setup_routes(self):
 
@@ -85,7 +85,7 @@ class MuxRouter:
             model_route = await self._get_model_route(thing_to_match)
             if not model_route:
                 raise HTTPException(
-                    "No matching rule found for the active workspace", status_code=404
+                    detail="No matching rule found for the active workspace", status_code=404
                 )
 
             logger.info(


### PR DESCRIPTION
We receive messages from Cline in the format
```
"messages": [
  {"role": "system", "content": "You are Cline, a highly skilled software"},
  {
     "role": "user",
     "content": [
       {
         "type": "text",
         "text": "Here is the content"
       }
     ]
]
```

Fixed the unit test and added a new one for Continue