### PR TITLE
Update the Facebook secret key regex at signatures.yaml

### DIFF
--- a/signatures.yaml
+++ b/signatures.yaml
@@ -104,7 +104,7 @@
     - Page Access Token: (?i)(EAAG[0-9A-Za-z]{10,128})
     - Facebook Access Token: EAACEdEose0cBA[0-9A-Za-z]+
     - Facebook Client ID: (?i)(facebook|fb)(.{0,20})?['\"][0-9]{13,17}
-    - Facebook Secret Key: (?i)(facebook|fb)(.{0,20})?(?-i)['\"][0-9a-f]{32}
+    - Facebook Secret Key: (?i)(facebook|fb)(.{0,20})?['\"][0-9a-fA-F]{32}
     #- Client Token: (?i)fb[a-zA-Z0-9]{24,32}
     - Instagram Access Token: (?i)(IGQV[0-9A-Za-z-_]{10,255})
     - Instagram App Secret: (?i)(ig_[a-f0-9]{32})


### PR DESCRIPTION
This should fix a warning in the CodeGate logs - 

```bash
2025-02-10T14:14:32.668331Z [warning  ] Invalid regex pattern '(?i)(facebook|fb)(.{0,20})?(?-i)['\"][0-9a-f]{32}': missing : at position 31 lineno=144 module=signatures pathname=/Users/dimitrovr/stacklok/codegate/src/codegate/pipeline/secrets/signatures.py
2025-02-10T14:14:32.668459Z [warning  ] Skipping invalid regex for Meta:Facebook Secret Key lineno=183 module=signatures pathname=/Users/dimitrovr/stacklok/codegate/src/codegate/pipeline/secrets/signatures.py
```