### PR TITLE
Pass down base URL and API key to completion handler

### DIFF
--- a/src/codegate/providers/anthropic/completion_handler.py
+++ b/src/codegate/providers/anthropic/completion_handler.py
@@ -13,6 +13,7 @@ class AnthropicCompletion(LiteLLmShim):
     async def execute_completion(
         self,
         request: ChatCompletionRequest,
+        base_url: Optional[str],
         api_key: Optional[str],
         stream: bool = False,
         is_fim_request: bool = False,

--- a/src/codegate/providers/base.py
+++ b/src/codegate/providers/base.py
@@ -257,6 +257,7 @@ class BaseProvider(ABC):
         # based on the streaming flag
         model_response = await self._completion_handler.execute_completion(
             provider_request,
+            base_url=data.get("base_url"),
             api_key=api_key,
             stream=streaming,
             is_fim_request=is_fim_request,

--- a/src/codegate/providers/completion/base.py
+++ b/src/codegate/providers/completion/base.py
@@ -19,6 +19,7 @@ class BaseCompletionHandler(ABC):
     async def execute_completion(
         self,
         request: ChatCompletionRequest,
+        base_url: Optional[str],
         api_key: Optional[str],
         stream: bool = False,  # TODO: remove this param?
         is_fim_request: bool = False,

--- a/src/codegate/providers/litellmshim/litellmshim.py
+++ b/src/codegate/providers/litellmshim/litellmshim.py
@@ -41,6 +41,7 @@ class LiteLLmShim(BaseCompletionHandler):
     async def execute_completion(
         self,
         request: ChatCompletionRequest,
+        base_url: Optional[str],
         api_key: Optional[str],
         stream: bool = False,
         is_fim_request: bool = False,
@@ -49,6 +50,7 @@ class LiteLLmShim(BaseCompletionHandler):
         Execute the completion request with LiteLLM's API
         """
         request["api_key"] = api_key
+        request["base_url"] = base_url
         if is_fim_request:
             return await self._fim_completion_func(**request)
         return await self._completion_func(**request)

--- a/src/codegate/providers/ollama/completion_handler.py
+++ b/src/codegate/providers/ollama/completion_handler.py
@@ -82,17 +82,26 @@ async def ollama_stream_generator(  # noqa: C901
 
 class OllamaShim(BaseCompletionHandler):
 
-    def __init__(self, base_url):
-        self.client = AsyncClient(host=base_url, timeout=300)
-
     async def execute_completion(
         self,
         request: ChatCompletionRequest,
+        base_url: Optional[str],
         api_key: Optional[str],
         stream: bool = False,
         is_fim_request: bool = False,
     ) -> Union[ChatResponse, GenerateResponse]:
         """Stream response directly from Ollama API."""
+
+        if not base_url:
+            raise ValueError("base_url is required for Ollama")
+
+        # TODO: Add CodeGate user agent.
+        headers = dict()
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        client = AsyncClient(host=base_url, timeout=300, headers=headers)
+
         if is_fim_request:
             prompt = ""
             for i in reversed(range(len(request["messages"]))):
@@ -102,7 +111,7 @@ class OllamaShim(BaseCompletionHandler):
             if not prompt:
                 raise ValueError("No user message found in FIM request")
 
-            response = await self.client.generate(
+            response = await client.generate(
                 model=request["model"],
                 prompt=prompt,
                 raw=request.get("raw", False),
@@ -111,7 +120,7 @@ class OllamaShim(BaseCompletionHandler):
                 options=request["options"],  # type: ignore
             )
         else:
-            response = await self.client.chat(
+            response = await client.chat(
                 model=request["model"],
                 messages=request["messages"],
                 stream=stream,  # type: ignore

--- a/src/codegate/providers/ollama/provider.py
+++ b/src/codegate/providers/ollama/provider.py
@@ -28,7 +28,7 @@ class OllamaProvider(BaseProvider):
         else:
             provided_urls = config.provider_urls
         self.base_url = provided_urls.get("ollama", "http://localhost:11434/")
-        completion_handler = OllamaShim(self.base_url)
+        completion_handler = OllamaShim()
         super().__init__(
             OllamaInputNormalizer(),
             OllamaOutputNormalizer(),
@@ -68,7 +68,7 @@ class OllamaProvider(BaseProvider):
         try:
             stream = await self.complete(
                 data,
-                api_key=None,
+                api_key=api_key,
                 is_fim_request=is_fim_request,
                 client_type=client_type,
             )


### PR DESCRIPTION
In order to make Ollama work with API Keys, I needed to change the
completion handler to take a base URL and also leverage a given API key
(if available).

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
Co-Authored-by: Alejandro Ponce de Leon <aponcedeleonch@stacklok.com>
