### PR TITLE
Force ANSI character output when running integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -273,7 +273,7 @@ jobs:
         env:
           CODEGATE_PROVIDERS: ${{ matrix.test-provider }}
         run: |
-          poetry run python tests/integration/integration_tests.py
+          poetry run --ansi python tests/integration/integration_tests.py
 
       - name: Logs - CodeGate container
         if: always()


### PR DESCRIPTION
The intention is to output everything, since currently we're missing
stderr.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
