### PR TITLE
Add codegate package path to poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ version = "0.1.7"
 description = "Generative AI CodeGen security gateway"
 readme = "README.md"
 authors = []
-
+packages = [
+    { include = "codegate", from = "src" },
+]
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
 click = "==8.1.8"

--- a/tests/integration/integration_tests.py
+++ b/tests/integration/integration_tests.py
@@ -136,6 +136,8 @@ class CodegateTestRunner:
         streaming = data.get("stream", False)
         provider = test["provider"]
 
+        logger.info(f"Starting test: {test_name}")
+
         response = self.call_codegate(url, test_headers, data, provider)
         if not response:
             logger.error(f"Test {test_name} failed: No response received")


### PR DESCRIPTION
I started getting this weird error when doing poetry install. My understanding is this helps poetry find where the codegate package is located. Let me know if it's wrong to have it, but it did fixed the issue on my side.

Also adds a simple log message for the integration tests.