### PR TITLE
Enable provider model updating when updating provider itself

### DIFF
--- a/src/codegate/providers/ollama/provider.py
+++ b/src/codegate/providers/ollama/provider.py
@@ -1,5 +1,5 @@
 import json
-from typing import List, Optional
+from typing import List
 
 import httpx
 import structlog


### PR DESCRIPTION
This now calls the model updating logic when updating the provider
itself. Thus allowing us to have a way to update the model list.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
