### PR TITLE
Fix anthropic format in integration tests

### DIFF
--- a/tests/integration/anthropic/testcases.yaml
+++ b/tests/integration/anthropic/testcases.yaml
@@ -10,11 +10,8 @@ testcases:
     data: |
       {
         "max_tokens":4096,
+        "system": "You are a coding assistant.",
         "messages":[
-            {
-              "content":"You are a coding assistant.",
-              "role":"system"
-            },
             {
               "content":"Reply with that exact sentence: Hello from the integration tests!",
               "role":"user"


### PR DESCRIPTION
The test probably worked by accident through some litellm magic, but
this is not how Anthropic messages are formatted and as we move toward
native messages, it would bite us.
