### PR TITLE
Fix ollama support for Kodu when muxing

### DIFF
--- a/src/codegate/muxing/adapter.py
+++ b/src/codegate/muxing/adapter.py
@@ -158,7 +158,12 @@ class ChatStreamChunkFormatter(StreamChunkFormatter):
             ollama_chunk = ChatResponse(**chunk_dict)
             open_ai_chunk = OLlamaToModel.normalize_chat_chunk(ollama_chunk)
             return open_ai_chunk.model_dump_json(exclude_none=True, exclude_unset=True)
-        except Exception:
+        except Exception as e:
+            # Sometimes we receive an OpenAI formatted chunk from ollama. Specifically when
+            # talking to Cline or Kodu. If that's the case we use the format_openai function.
+            if "data:" in chunk:
+                return self._format_openai(chunk)
+            logger.warning(f"Error formatting Ollama chunk: {chunk}. Error: {e}")
             return chunk
 
     def _format_antropic(self, chunk: str) -> str:


### PR DESCRIPTION
Muixing was failing for 2 reasons:

1. Sometimes we return OpenAI format from ollama provider. Before we were assuming that everything that was returned from ollama provider had ollama format.
2. The OpenAI format returned from ollama provider had an invalid `created` field.