### PR TITLE
Add set_text to Anthropic UserMessage to enable raw string messages

### DIFF
--- a/src/codegate/types/anthropic/_request_models.py
+++ b/src/codegate/types/anthropic/_request_models.py
@@ -94,6 +94,14 @@ class UserMessage(pydantic.BaseModel):
             for content in self.content:
                 yield content
 
+    def set_text(self, txt: str) -> None:
+        if isinstance(self.content, str):
+            self.content = txt
+            return
+
+        # should have been called on the content
+        raise ValueError("Cannot set text on a list of content")
+
 
 class AssistantMessage(pydantic.BaseModel):
     role: Literal["assistant"]


### PR DESCRIPTION
In case the message is just a text and not a MessageContent, we need to set self.content. Otherwise, the method will be called on MessageContent which is already implemented.