### PR TITLE
Add integration checks for comparing the result of calling the model API directly vs via CodeGate

### DIFF
--- a/tests/integration/checks.py
+++ b/tests/integration/checks.py
@@ -29,7 +29,8 @@ class CheckLoader:
             checks.append(ContainsCheck(test_name))
         if test_data.get(DoesNotContainCheck.KEY):
             checks.append(DoesNotContainCheck(test_name))
-
+        if test_data.get(CodeGateEnrichment.KEY) is not None:
+            checks.append(CodeGateEnrichment(test_name))
         return checks
 
 
@@ -51,11 +52,10 @@ class DistanceCheck(BaseCheck):
         similarity = await self._calculate_string_similarity(
             parsed_response, test_data[DistanceCheck.KEY]
         )
+        logger.debug(f"Similarity: {similarity}")
+        logger.debug(f"Response: {parsed_response}")
+        logger.debug(f"Expected Response: {test_data[DistanceCheck.KEY]}")
         if similarity < 0.8:
-            logger.error(f"Test {self.test_name} failed")
-            logger.error(f"Similarity: {similarity}")
-            logger.error(f"Response: {parsed_response}")
-            logger.error(f"Expected Response: {test_data[DistanceCheck.KEY]}")
             return False
         return True
 
@@ -64,10 +64,9 @@ class ContainsCheck(BaseCheck):
     KEY = "contains"
 
     async def run_check(self, parsed_response: str, test_data: dict) -> bool:
+        logger.debug(f"Response: {parsed_response}")
+        logger.debug(f"Expected Response to contain: {test_data[ContainsCheck.KEY]}")
         if test_data[ContainsCheck.KEY].strip() not in parsed_response:
-            logger.error(f"Test {self.test_name} failed")
-            logger.error(f"Response: {parsed_response}")
-            logger.error(f"Expected Response to contain: '{test_data[ContainsCheck.KEY]}'")
             return False
         return True
 
@@ -76,11 +75,33 @@ class DoesNotContainCheck(BaseCheck):
     KEY = "does_not_contain"
 
     async def run_check(self, parsed_response: str, test_data: dict) -> bool:
+        logger.debug(f"Response: {parsed_response}")
+        logger.debug(f"Expected Response to not contain: '{test_data[DoesNotContainCheck.KEY]}'")
         if test_data[DoesNotContainCheck.KEY].strip() in parsed_response:
-            logger.error(f"Test {self.test_name} failed")
-            logger.error(f"Response: {parsed_response}")
-            logger.error(
-                f"Expected Response to not contain: '{test_data[DoesNotContainCheck.KEY]}'"
-            )
             return False
         return True
+
+
+class CodeGateEnrichment(BaseCheck):
+    KEY = "codegate_enrichment"
+
+    async def run_check(self, parsed_response: str, test_data: dict) -> bool:
+        direct_response = test_data["direct_response"]
+        logger.debug(f"Response (CodeGate): {parsed_response}")
+        logger.debug(f"Response (Raw model): {direct_response}")
+
+        # Use the DistanceCheck to compare the two responses
+        distance_check = DistanceCheck(self.test_name)
+        are_similar = await distance_check.run_check(
+            parsed_response, {DistanceCheck.KEY: direct_response}
+        )
+
+        # Check if the response is enriched by CodeGate.
+        # If it is, there should be a difference in the similarity score.
+        expect_enrichment = test_data.get(CodeGateEnrichment.KEY).get("expect_difference", False)
+        if expect_enrichment:
+            logger.info("CodeGate enrichment check: Expecting difference")
+            return not are_similar
+        # If the response is not enriched, the similarity score should be the same.
+        logger.info("CodeGate enrichment check: Not expecting difference")
+        return are_similar

--- a/tests/integration/ollama/testcases.yaml
+++ b/tests/integration/ollama/testcases.yaml
@@ -31,6 +31,9 @@ testcases:
     name: Ollama Chat
     provider: ollama
     url: http://127.0.0.1:8989/ollama/chat/completions
+    codegate_enrichment:
+      provider_url: http://127.0.0.1:11434/api/chat
+      expect_difference: false
     data: |
       {
         "max_tokens":4096,
@@ -55,6 +58,9 @@ testcases:
     name: Ollama FIM
     provider: ollama
     url: http://127.0.0.1:8989/ollama/api/generate
+    codegate_enrichment:
+      provider_url: http://127.0.0.1:11434/api/generate
+      expect_difference: false
     data: |
       {
         "stream": true,
@@ -88,6 +94,9 @@ testcases:
     name: Ollama Malicious Package
     provider: ollama
     url: http://127.0.0.1:8989/ollama/chat/completions
+    codegate_enrichment:
+      provider_url: http://127.0.0.1:11434/api/chat
+      expect_difference: true
     data: |
       {
         "max_tokens":4096,
@@ -112,6 +121,9 @@ testcases:
     name: Ollama secret redacting chat
     provider: ollama
     url: http://127.0.0.1:8989/ollama/chat/completions
+    codegate_enrichment:
+      provider_url: http://127.0.0.1:11434/api/chat
+      expect_difference: true
     data: |
       {
         "max_tokens":4096,

--- a/tests/integration/vllm/testcases.yaml
+++ b/tests/integration/vllm/testcases.yaml
@@ -31,6 +31,9 @@ testcases:
     name: VLLM Chat
     provider: vllm
     url: http://127.0.0.1:8989/vllm/chat/completions
+    codegate_enrichment:
+      provider_url: http://127.0.0.1:8000/v1/chat/completions
+      expect_difference: false
     data: |
       {
         "max_tokens":4096,
@@ -55,6 +58,10 @@ testcases:
     name: VLLM FIM
     provider: vllm
     url: http://127.0.0.1:8989/vllm/completions
+# This is commented out for now as there's some issue with parsing the streamed response from the model (on the vllm side, not codegate)
+#    codegate_enrichment:
+#      provider_url: http://127.0.0.1:8000/v1/completions
+#      expect_difference: false
     data: |
       {
         "model": "Qwen/Qwen2.5-Coder-0.5B-Instruct",
@@ -84,6 +91,9 @@ testcases:
     name: VLLM Malicious Package
     provider: vllm
     url: http://127.0.0.1:8989/vllm/chat/completions
+    codegate_enrichment:
+      provider_url: http://127.0.0.1:8000/v1/chat/completions
+      expect_difference: true
     data: |
       {
         "max_tokens":4096,


### PR DESCRIPTION
This introduces the following format:

```yaml
    codegate_enrichment:
      provider_url: http://127.0.0.1:11434/api/chat
      expect_difference: false
```

Fixes: #841 