### PR TITLE
Add integration tests with muxing

### DIFF
--- a/tests/integration/anthropic/testcases.yaml
+++ b/tests/integration/anthropic/testcases.yaml
@@ -2,6 +2,31 @@ headers:
   anthropic:
     x-api-key: ENV_ANTHROPIC_KEY
 
+muxing:
+  mux_url: http://127.0.0.1:8989/v1/mux/
+  trimm_from_testcase_url: http://127.0.0.1:8989/anthropic/
+  provider_endpoint:
+    url: http://127.0.0.1:8989/api/v1/provider-endpoints
+    headers:
+      Content-Type: application/json
+    data: |
+      {
+        "name": "anthropic_muxing",
+        "description": "Muxing testing endpoint",
+        "provider_type": "anthropic",
+        "endpoint": "https://api.anthropic.com/",
+        "auth_type": "api_key",
+        "api_key": "ENV_ANTHROPIC_KEY"
+      }
+  muxes:
+    url: http://127.0.0.1:8989/api/v1/workspaces/default/muxes
+    headers:
+      Content-Type: application/json
+    rules:
+      - model: claude-3-5-haiku-20241022
+        matcher_type: catch_all
+        matcher: ""
+
 testcases:
   anthropic_chat:
     name: Anthropic Chat

--- a/tests/integration/llamacpp/testcases.yaml
+++ b/tests/integration/llamacpp/testcases.yaml
@@ -2,6 +2,30 @@ headers:
   llamacpp:
     Content-Type: application/json
 
+muxing:
+  mux_url: http://127.0.0.1:8989/v1/mux/
+  trimm_from_testcase_url: http://127.0.0.1:8989/llamacpp/
+  provider_endpoint:
+    url: http://127.0.0.1:8989/api/v1/provider-endpoints
+    headers:
+      Content-Type: application/json
+    data: |
+      {
+        "name": "llamacpp_muxing",
+        "description": "Muxing testing endpoint",
+        "provider_type": "llamacpp",
+        "endpoint": "./codegate_volume/models",
+        "auth_type": "none"
+      }
+  muxes:
+    url: http://127.0.0.1:8989/api/v1/workspaces/default/muxes
+    headers:
+      Content-Type: application/json
+    rules:
+      - model: qwen2.5-coder-0.5b-instruct-q5_k_m
+        matcher_type: catch_all
+        matcher: ""
+
 testcases:
   llamacpp_chat:
     name: LlamaCPP Chat

--- a/tests/integration/ollama/testcases.yaml
+++ b/tests/integration/ollama/testcases.yaml
@@ -2,6 +2,30 @@ headers:
   ollama:
     Content-Type: application/json
 
+muxing:
+  mux_url: http://127.0.0.1:8989/v1/mux/
+  trimm_from_testcase_url: http://127.0.0.1:8989/ollama/
+  provider_endpoint:
+    url: http://127.0.0.1:8989/api/v1/provider-endpoints
+    headers:
+      Content-Type: application/json
+    data: |
+      {
+        "name": "ollama_muxing",
+        "description": "Muxing testing endpoint",
+        "provider_type": "ollama",
+        "endpoint": "http://127.0.0.1:11434",
+        "auth_type": "none"
+      }
+  muxes:
+    url: http://127.0.0.1:8989/api/v1/workspaces/default/muxes
+    headers:
+      Content-Type: application/json
+    rules:
+      - model: qwen2.5-coder:1.5b
+        matcher_type: catch_all
+        matcher: ""
+
 testcases:
   ollama_chat:
     name: Ollama Chat

--- a/tests/integration/openai/testcases.yaml
+++ b/tests/integration/openai/testcases.yaml
@@ -2,6 +2,31 @@ headers:
   openai:
     Authorization: Bearer ENV_OPENAI_KEY
 
+muxing:
+  mux_url: http://127.0.0.1:8989/v1/mux/
+  trimm_from_testcase_url: http://127.0.0.1:8989/openai/
+  provider_endpoint:
+    url: http://127.0.0.1:8989/api/v1/provider-endpoints
+    headers:
+      Content-Type: application/json
+    data: |
+      {
+        "name": "openai_muxing",
+        "description": "Muxing testing endpoint",
+        "provider_type": "openai",
+        "endpoint": "https://api.openai.com/",
+        "auth_type": "api_key",
+        "api_key": "ENV_OPENAI_KEY"
+      }
+  muxes:
+    url: http://127.0.0.1:8989/api/v1/workspaces/default/muxes
+    headers:
+      Content-Type: application/json
+    rules:
+      - model: gpt-4o-mini
+        matcher_type: catch_all
+        matcher: ""
+
 testcases:
   openai_chat:
     name: OpenAI Chat

--- a/tests/integration/openrouter/testcases.yaml
+++ b/tests/integration/openrouter/testcases.yaml
@@ -2,6 +2,31 @@ headers:
   openrouter:
     Authorization: Bearer ENV_OPENROUTER_KEY
 
+muxing:
+  mux_url: http://127.0.0.1:8989/v1/mux/
+  trimm_from_testcase_url: http://localhost:8989/openrouter/
+  provider_endpoint:
+    url: http://127.0.0.1:8989/api/v1/provider-endpoints
+    headers:
+      Content-Type: application/json
+    data: |
+      {
+        "name": "openrouter_muxing",
+        "description": "Muxing testing endpoint",
+        "provider_type": "openrouter",
+        "endpoint": "https://openrouter.ai/api",
+        "auth_type": "api_key",
+        "api_key": "ENV_OPENROUTER_KEY"
+      }
+  muxes:
+    url: http://127.0.0.1:8989/api/v1/workspaces/default/muxes
+    headers:
+      Content-Type: application/json
+    rules:
+      - model: anthropic/claude-3.5-haiku
+        matcher_type: catch_all
+        matcher: ""
+
 testcases:
   anthropic_chat:
     name: Openrouter Chat

--- a/tests/integration/requesters.py
+++ b/tests/integration/requesters.py
@@ -11,33 +11,43 @@ logger = structlog.get_logger("codegate")
 
 class BaseRequester(ABC):
     @abstractmethod
-    def make_request(self, url: str, headers: dict, data: dict) -> Optional[requests.Response]:
+    def make_request(
+        self, url: str, headers: dict, data: dict, method: str = "POST"
+    ) -> Optional[requests.Response]:
         pass
 
 
 class StandardRequester(BaseRequester):
-    def make_request(self, url: str, headers: dict, data: dict) -> Optional[requests.Response]:
+    def make_request(
+        self, url: str, headers: dict, data: dict, method: str = "POST"
+    ) -> Optional[requests.Response]:
         # Ensure Content-Type is always set correctly
         headers["Content-Type"] = "application/json"
 
         # Explicitly serialize to JSON string
         json_data = json.dumps(data)
 
-        return requests.post(
-            url, headers=headers, data=json_data  # Use data instead of json parameter
+        return requests.request(
+            method=method,
+            url=url,
+            headers=headers,
+            data=json_data,  # Use data instead of json parameter
         )
 
 
 class CopilotRequester(BaseRequester):
-    def make_request(self, url: str, headers: dict, data: dict) -> Optional[requests.Response]:
+    def make_request(
+        self, url: str, headers: dict, data: dict, method: str = "POST"
+    ) -> Optional[requests.Response]:
         # Ensure Content-Type is always set correctly
         headers["Content-Type"] = "application/json"
 
         # Explicitly serialize to JSON string
         json_data = json.dumps(data)
 
-        return requests.post(
-            url,
+        return requests.request(
+            method=method,
+            url=url,
             data=json_data,  # Use data instead of json parameter
             headers=headers,
             proxies={"https": "https://localhost:8990", "http": "http://localhost:8990"},

--- a/tests/integration/vllm/testcases.yaml
+++ b/tests/integration/vllm/testcases.yaml
@@ -2,6 +2,30 @@ headers:
   vllm:
     Content-Type: application/json
 
+muxing:
+  mux_url: http://127.0.0.1:8989/v1/mux/
+  trimm_from_testcase_url: http://127.0.0.1:8989/vllm/
+  provider_endpoint:
+    url: http://127.0.0.1:8989/api/v1/provider-endpoints
+    headers:
+      Content-Type: application/json
+    data: |
+      {
+        "name": "vllm_muxing",
+        "description": "Muxing testing endpoint",
+        "provider_type": "vllm",
+        "endpoint": "http://127.0.0.1:8000",
+        "auth_type": "none"
+      }
+  muxes:
+    url: http://127.0.0.1:8989/api/v1/workspaces/default/muxes
+    headers:
+      Content-Type: application/json
+    rules:
+      - model: Qwen/Qwen2.5-Coder-0.5B-Instruct
+        matcher_type: catch_all
+        matcher: ""
+
 testcases:
   vllm_chat:
     name: VLLM Chat

--- a/tests/muxing/test_adapter.py
+++ b/tests/muxing/test_adapter.py
@@ -22,6 +22,7 @@ class MockedModelRoute:
         (ProviderType.openrouter, "https://openrouter.ai/api", "https://openrouter.ai/api/v1"),
         (ProviderType.openrouter, "https://openrouter.ai/", "https://openrouter.ai/api/v1"),
         (ProviderType.ollama, "http://localhost:11434", "http://localhost:11434"),
+        (ProviderType.vllm, "http://localhost:8000", "http://localhost:8000/v1"),
     ],
 )
 def test_catch_all(provider_type, endpoint_route, expected_route):


### PR DESCRIPTION
Replicate the current integration tests but instead of using the specific provider URL, e.g. `/ollama` use the muxing URL, i.e. `/v1/mux/`.

Muxing functionality should take care of routing the request to the correct model and provider. For the moment we're only going to test with the "catch_all" rule. Meaning, all the requests will be directed to the same model.

In future iterations we can expand the integration tests to check for multiple rules across different providers.