### PR TITLE
Test build the CodeGate image for arm64 too

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -43,13 +43,13 @@ jobs:
         run: |
           git lfs install
           git lfs pull
-      - name: Test build on x86
+      - name: Test build on arm64 and amd64
         id: docker_build
         uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v5
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: false # Only attempt to build, to verify the Dockerfile is working
           load: true
           cache-from: type=gha

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Set up QEMU for cross-platform builds
+        uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3
       - name: Download artifact
@@ -51,7 +53,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: false # Only attempt to build, to verify the Dockerfile is working
-          load: true
+#          load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -8,6 +8,10 @@ on:
         description: 'The name of the artifact to upload'
         required: true
         type: string
+      platform:
+        description: 'The platform to build the image for'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -23,6 +27,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Set up QEMU for cross-platform builds
+        # Only set up QEMU if the platform is not linux/amd64
+        if: ${{ inputs.platform != 'linux/amd64' }}
         uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3
@@ -45,27 +51,31 @@ jobs:
         run: |
           git lfs install
           git lfs pull
-      - name: Test build on arm64 and amd64
+      - name: Test build - ${{ inputs.platform }}
         id: docker_build
         uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v5
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ inputs.platform }}
           push: false # Only attempt to build, to verify the Dockerfile is working
-#          load: true
+          load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
             LATEST_RELEASE=${{ env.LATEST_RELEASE }}
           tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
       - name: Save Docker image as a tarball
+        # Only save the image if the build was for linux/amd64, as we only need it for the integration tests
+        if: ${{ inputs.platform == 'linux/amd64' }}
         run: |
           # List all images
           docker images
           # Save the image as a tarball
           docker save -o image.tar ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
       - name: Upload Docker image artifact
+        # Only upload the image if the build was for linux/amd64, as we only need it for the integration tests
+        if: ${{ inputs.platform == 'linux/amd64' }}
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
           name: ${{ inputs.artifact-name }}

--- a/.github/workflows/run-on-pr.yml
+++ b/.github/workflows/run-on-pr.yml
@@ -14,10 +14,17 @@ jobs:
     name: Build, Test & Lint
     uses: ./.github/workflows/ci.yml
   image-build:
-    name: OCI Image - Build
+    name: OCI Image - Build x86
     uses: ./.github/workflows/image-build.yml
     with:
       artifact-name: "codegate-image"
+      platform: "linux/amd64"
+  image-build-arm64:
+    name: OCI Image - Build ARM64
+    uses: ./.github/workflows/image-build.yml
+    with:
+      artifact-name: "codegate-image"
+      platform: "linux/arm64"
   integration-tests:
     if: github.event.pull_request.head.repo.full_name == 'stacklok/codegate'
     name: Integration Tests

--- a/.github/workflows/run-on-push.yml
+++ b/.github/workflows/run-on-push.yml
@@ -14,10 +14,17 @@ jobs:
     name: Build, Test & Lint
     uses: ./.github/workflows/ci.yml
   image-build:
-    name: OCI Image - Build
+    name: OCI Image - Build x86
     uses: ./.github/workflows/image-build.yml
     with:
       artifact-name: "codegate-image"
+      platform: "linux/amd64"
+  image-build-arm64:
+    name: OCI Image - Build ARM64
+    uses: ./.github/workflows/image-build.yml
+    with:
+      artifact-name: "codegate-image"
+      platform: "linux/arm64"
   integration-tests:
     name: Integration Tests
     needs: [ci, image-build] # We need the image available in order to run the integration tests


### PR DESCRIPTION
The following PR build the image for both arm64 and amd64.

It also splits the image build workflow to accept the platform as an input variable so we don't block the tests from running while the arm image is building.