### PR TITLE
Only handle user messages with text, not None

### DIFF
--- a/src/codegate/pipeline/base.py
+++ b/src/codegate/pipeline/base.py
@@ -227,7 +227,10 @@ class PipelineStep(ABC):
         last_idx = -1
         for msg, idx in request.last_user_block():
             for content in msg.get_content():
-                user_messages.append(content.get_text())
+                txt = content.get_text()
+                if not txt:
+                    continue
+                user_messages.append(txt)
                 last_idx = idx
 
         if user_messages == []:

--- a/src/codegate/pipeline/output.py
+++ b/src/codegate/pipeline/output.py
@@ -114,7 +114,8 @@ class OutputPipelineInstance:
         streamed through the pipeline.
         """
         for content in chunk.get_content():
-            for text in content.get_text():
+            text = content.get_text()
+            if text:
                 self._context.processed_content.append(text)
 
     def _record_to_db(self) -> None:


### PR DESCRIPTION
Tool calls have no content, we should not handle them. This bug triggered issues with the agentic copilot.