### PR TITLE
Fix API alerts and storing of PII alerts

### DIFF
--- a/src/codegate/api/v1.py
+++ b/src/codegate/api/v1.py
@@ -414,7 +414,9 @@ async def get_workspace_messages(workspace_name: str) -> List[v1_models.Conversa
 
     try:
         prompts_with_output_alerts_usage = (
-            await dbreader.get_prompts_with_output_alerts_usage_by_workspace_id(ws.id)
+            await dbreader.get_prompts_with_output_alerts_usage_by_workspace_id(
+                ws.id, AlertSeverity.CRITICAL.value
+            )
         )
         conversations, _ = await v1_processing.parse_messages_in_conversations(
             prompts_with_output_alerts_usage

--- a/src/codegate/api/v1_processing.py
+++ b/src/codegate/api/v1_processing.py
@@ -534,4 +534,4 @@ async def remove_duplicate_alerts(alerts: List[v1_models.Alert]) -> List[v1_mode
         seen[key] = alert
         unique_alerts.append(alert)
 
-    return list(seen.values())
+    return unique_alerts

--- a/src/codegate/pipeline/pii/analyzer.py
+++ b/src/codegate/pipeline/pii/analyzer.py
@@ -100,7 +100,7 @@ class PiiAnalyzer:
         PiiAnalyzer._instance = self
 
     def analyze(
-        self, text: str, context: Optional["PipelineContext"] = None
+        self, text: str, context: Optional[PipelineContext] = None
     ) -> Tuple[str, List[Dict[str, Any]], PiiSessionStore]:
         # Prioritize credit card detection first
         entities = [

--- a/src/codegate/pipeline/pii/manager.py
+++ b/src/codegate/pipeline/pii/manager.py
@@ -1,7 +1,8 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import structlog
 
+from codegate.pipeline.base import PipelineContext
 from codegate.pipeline.pii.analyzer import PiiAnalyzer, PiiSessionStore
 
 logger = structlog.get_logger("codegate")
@@ -52,9 +53,11 @@ class PiiManager:
         # Always return the analyzer's current session store
         return self.analyzer.session_store
 
-    def analyze(self, text: str) -> Tuple[str, List[Dict[str, Any]]]:
+    def analyze(
+        self, text: str, context: Optional[PipelineContext] = None
+    ) -> Tuple[str, List[Dict[str, Any]]]:
         # Call analyzer and get results
-        anonymized_text, found_pii, _ = self.analyzer.analyze(text)
+        anonymized_text, found_pii, _ = self.analyzer.analyze(text, context=context)
 
         # Log found PII details (without modifying the found_pii list)
         if found_pii:

--- a/src/codegate/pipeline/pii/pii.py
+++ b/src/codegate/pipeline/pii/pii.py
@@ -80,7 +80,7 @@ class CodegatePii(PipelineStep):
             if "content" in message and message["content"]:
                 # This is where analyze and anonymize the text
                 original_text = str(message["content"])
-                anonymized_text, pii_details = self.pii_manager.analyze(original_text)
+                anonymized_text, pii_details = self.pii_manager.analyze(original_text, context)
 
                 if pii_details:
                     total_pii_found += len(pii_details)

--- a/tests/pipeline/pii/test_pii_manager.py
+++ b/tests/pipeline/pii/test_pii_manager.py
@@ -44,7 +44,7 @@ class TestPiiManager:
         assert anonymized_text == text
         assert found_pii == []
         assert manager.session_store is session_store
-        mock_analyzer.analyze.assert_called_once_with(text)
+        mock_analyzer.analyze.assert_called_once_with(text, context=None)
 
     def test_analyze_with_pii(self, manager, mock_analyzer):
         text = "My email is test@example.com"
@@ -71,7 +71,7 @@ class TestPiiManager:
         assert found_pii == pii_details
         assert manager.session_store is session_store
         assert manager.session_store.mappings[placeholder] == "test@example.com"
-        mock_analyzer.analyze.assert_called_once_with(text)
+        mock_analyzer.analyze.assert_called_once_with(text, context=None)
 
     def test_restore_pii_no_session(self, manager, mock_analyzer):
         text = "Anonymized text"


### PR DESCRIPTION
We had some small bugs related with alerts:
1. The function for deduping alerts was only returning alerts related to secrets. All the other alerts were being dropped when calling this function.
2. We were returning non-critical alerts in the `/messages/` endpoint
3. PII alerts were never recorded because the context was never passed to the function. Discovered by @kantord 

This PR fixes the 3 of them and introduces some unit tests.