### PR TITLE
Dump raw JSON messages

### DIFF
--- a/src/codegate/providers/base.py
+++ b/src/codegate/providers/base.py
@@ -217,6 +217,10 @@ class BaseProvider(ABC):
 
             with open(fname, "w") as f:
                 json.dump(data, f, indent=2)
+        elif hasattr(data, "json"):
+            # The new format
+            with open(fname, "w") as f:
+                f.write(data.json())
         else:
             with open(fname, "w") as f:
                 f.write(str(data))


### PR DESCRIPTION
This amends the helper that dumps the requests to dump the JSON as represented by the models instead of a printable representation of the models.