### PR TITLE
fix: add space after "data:" in muxing adapter

### DIFF
--- a/src/codegate/muxing/adapter.py
+++ b/src/codegate/muxing/adapter.py
@@ -136,7 +136,7 @@ class StreamChunkFormatter(OutputFormatter):
 
     def _format_as_openai_chunk(self, formatted_chunk: str) -> str:
         """Format the chunk as OpenAI chunk. This is the format how the clients expect the data."""
-        chunk_to_send = f"data:{formatted_chunk}\n\n"
+        chunk_to_send = f"data: {formatted_chunk}\n\n"
         return chunk_to_send
 
     async def _format_streaming_response(


### PR DESCRIPTION
the same fix as in https://github.com/stacklok/codegate/pull/1087, but for muxing.

Related to #901 