### PR TITLE
Pass through reasoning input flag and output chunks

### DIFF
--- a/src/codegate/types/openai/_request_models.py
+++ b/src/codegate/types/openai/_request_models.py
@@ -318,6 +318,7 @@ class ChatCompletionRequest(pydantic.BaseModel):
     user: str | None = None
     function_call: str | FunctionChoice | None = "auto" # deprecated
     functions: List[LegacyFunctionDef] | None = None # deprecated
+    include_reasoning: bool | None = None # openrouter extension
 
     def get_stream(self) -> bool:
         return self.stream

--- a/src/codegate/types/openai/_response_models.py
+++ b/src/codegate/types/openai/_response_models.py
@@ -115,6 +115,7 @@ class MessageDelta(pydantic.BaseModel):
     tool_calls: List[ToolCall] | None = None
     role: Role | None = None
     function_call: FunctionCall | None = None # deprecated
+    reasoning: str | None = None # openrouter extension
 
 
 class ChoiceDelta(pydantic.BaseModel):


### PR DESCRIPTION
Some OpenRouter models allow to include the reasoning output if told to do so with a special input flag. This seems to be specific to OpenRouter.

A simple test is:
```
curl http://localhost:8989/openrouter/completions \
 -H "Authorization: Bearer $OPENROUTER_KEY" \
 -H "Content-Type: application/json" \
 -d '{
   "model": "deepseek/deepseek-r1",
   "messages": [
     {"role": "user", "content": "What is heavier, a kilogram of iron or a kilogram of feathers?"}
   ],
   "include_reasoning": true,
   "stream": true
 }'
```

Fixes: #977