### PR TITLE
Fix FIM for OpenRouter

### DIFF
--- a/src/codegate/providers/openai/provider.py
+++ b/src/codegate/providers/openai/provider.py
@@ -18,8 +18,9 @@ class OpenAIProvider(BaseProvider):
     def __init__(
         self,
         pipeline_factory: PipelineFactory,
+        # Enable receiving other completion handlers from childs, i.e. OpenRouter and LM Studio
+        completion_handler: LiteLLmShim = LiteLLmShim(stream_generator=sse_stream_generator),
     ):
-        completion_handler = LiteLLmShim(stream_generator=sse_stream_generator)
         super().__init__(
             OpenAIInputNormalizer(),
             OpenAIOutputNormalizer(),


### PR DESCRIPTION
FIM was not working with OpenRouter in Continue. The reason was that we get FIM requests in `/completions`. LiteLLM when using `acompletion` is forcing `/chat/completions` and the return format `{..., "choices":[{"delta":{"content":"some text"}}]}`. However, Continue was expecting the format: `{..., "choices":[{"text":"some text"}]}` becuase of the endpoint it called.

With this PR we force the return format to be the latter using `atext_completion` from LiteLLM