### PR TITLE
feat: add workspaces list endpoint by provider id

### DIFF
--- a/src/codegate/api/v1.py
+++ b/src/codegate/api/v1.py
@@ -534,7 +534,7 @@ async def set_workspace_muxes(
 
 @v1.get(
     "/workspaces/{provider_id}",
-    tags=["Providers"],
+    tags=["Workspaces"],
     generate_unique_id_function=uniq_name,
 )
 async def list_workspaces_by_provider(

--- a/src/codegate/api/v1.py
+++ b/src/codegate/api/v1.py
@@ -541,16 +541,9 @@ async def list_workspaces_by_provider(
     provider_id: UUID,
 ) -> List[WorkspaceWithModel]:
     """List workspaces by provider ID."""
-
     try:
-        workspaces = await wscrud.workspaces_by_provider(provider_id)
+        return await wscrud.workspaces_by_provider(provider_id)
 
-        return [
-            WorkspaceWithModel(id=ws.id, name=ws.name, provider_model_name=ws.provider_model_name)
-            for ws in workspaces
-        ]
-    except crud.WorkspaceDoesNotExistError:
-        raise HTTPException(status_code=404, detail="Workspaces not found")
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -28,6 +28,7 @@ from codegate.db.models import (
     ProviderModel,
     Session,
     WorkspaceRow,
+    WorkspaceWithModel,
     WorkspaceWithSessionInfo,
 )
 from codegate.db.token_usage import TokenUsageParser
@@ -720,6 +721,23 @@ class DbReader(DbCodeGate):
             WorkspaceRow, sql, conditions, should_raise=True
         )
         return workspaces[0] if workspaces else None
+
+    async def get_workspaces_by_provider(self, provider_id: str) -> List[WorkspaceWithModel]:
+        sql = text(
+            """
+            SELECT
+                w.id, w.name, m.provider_model_name
+            FROM workspaces w
+            JOIN muxes m ON w.id = m.workspace_id
+            WHERE m.provider_endpoint_id = :provider_id
+            AND w.deleted_at IS NULL
+            """
+        )
+        conditions = {"provider_id": provider_id}
+        workspaces = await self._exec_select_conditions_to_pydantic(
+            WorkspaceWithModel, sql, conditions, should_raise=True
+        )
+        return workspaces
 
     async def get_archived_workspace_by_name(self, name: str) -> Optional[WorkspaceRow]:
         sql = text(

--- a/src/codegate/db/models.py
+++ b/src/codegate/db/models.py
@@ -189,6 +189,14 @@ class WorkspaceWithSessionInfo(BaseModel):
     session_id: Optional[str]
 
 
+class WorkspaceWithModel(BaseModel):
+    """Returns a workspace ID with model name"""
+
+    id: str
+    name: WorkspaceNameStr
+    provider_model_name: str
+
+
 class ActiveWorkspace(BaseModel):
     """Returns a full active workspace object with the
     with the session information.

--- a/src/codegate/workspaces/crud.py
+++ b/src/codegate/workspaces/crud.py
@@ -218,6 +218,13 @@ class WorkspaceCrud:
             raise WorkspaceDoesNotExistError(f"Workspace {workspace_name} does not exist.")
         return workspace
 
+    async def workspaces_by_provider(self, provider_id: uuid) -> List[db_models.WorkspaceWithModel]:
+        """Get the workspaces by provider."""
+
+        workspaces = await self._db_reader.get_workspaces_by_provider(str(provider_id))
+
+        return workspaces
+
     async def get_muxes(self, workspace_name: str) -> List[mux_models.MuxRule]:
         # Verify if workspace exists
         workspace = await self._db_reader.get_workspace_by_name(workspace_name)


### PR DESCRIPTION
Added an endpoint `/workspaces/:provider_id` that return the list of workspaces by a provider id. This allow the dashboard to show the impacted workspaces in case of providers deletion. The dashboard will show a list of workspaces in the confirmation dialog before a provider will be deleted, in this way it is clear which workspaces are impacted.