### PR TITLE
feat: initial work on endpoints for creating/updating

### DIFF
--- a/src/codegate/api/v1_models.py
+++ b/src/codegate/api/v1_models.py
@@ -61,7 +61,7 @@ class ListActiveWorkspacesResponse(pydantic.BaseModel):
 
 
 class WorkspaceConfig(pydantic.BaseModel):
-    system_prompt: str
+    custom_instructions: str
 
     muxing_rules: List[mux_models.MuxRule]
 

--- a/src/codegate/muxing/models.py
+++ b/src/codegate/muxing/models.py
@@ -4,6 +4,7 @@ from typing import Optional
 import pydantic
 
 from codegate.clients.clients import ClientType
+from codegate.db.models import MuxRule as DbMuxRule
 
 
 class MuxMatcherType(str, Enum):
@@ -35,6 +36,19 @@ class MuxRule(pydantic.BaseModel):
     # The actual matcher to use. Note that
     # this depends on the matcher type.
     matcher: Optional[str] = None
+
+    @classmethod
+    def try_from_db_model(cls, db_model: DbMuxRule) -> "MuxRule":
+        try:
+            return cls(
+                provider_name=db_model.provider_endpoint_name,
+                provider_id=db_model.provider_endpoint_id,
+                model=db_model.provider_model_name,
+                matcher_type=MuxMatcherType(db_model.matcher_type),
+                matcher=db_model.matcher_blob,
+            )
+        except Exception as e:
+            raise ValueError(f"Error converting from DbMuxRule: {e}")
 
 
 class ThingToMatchMux(pydantic.BaseModel):

--- a/src/codegate/pipeline/cli/commands.py
+++ b/src/codegate/pipeline/cli/commands.py
@@ -98,7 +98,6 @@ class Version(CodegateCommand):
 
 
 class CodegateCommandSubcommand(CodegateCommand):
-
     @property
     @abstractmethod
     def subcommands(self) -> Dict[str, Callable[[List[str]], Awaitable[str]]]:
@@ -174,7 +173,6 @@ class CodegateCommandSubcommand(CodegateCommand):
 
 
 class Workspace(CodegateCommandSubcommand):
-
     def __init__(self):
         self.workspace_crud = crud.WorkspaceCrud()
 
@@ -258,7 +256,7 @@ class Workspace(CodegateCommandSubcommand):
             )
 
         try:
-            await self.workspace_crud.rename_workspace(old_workspace_name, new_workspace_name)
+            await self.workspace_crud.update_workspace(old_workspace_name, new_workspace_name)
         except crud.WorkspaceDoesNotExistError:
             return f"Workspace **{old_workspace_name}** does not exist"
         except AlreadyExistsError:
@@ -410,7 +408,6 @@ class Workspace(CodegateCommandSubcommand):
 
 
 class CustomInstructions(CodegateCommandSubcommand):
-
     def __init__(self):
         self.workspace_crud = crud.WorkspaceCrud()
 


### PR DESCRIPTION
Related to #1067 

- Modifies the existing POST `/workspaces`
  - it exclusively handles workspace creation — the ability to rename via this endpoint is removed
  - it can handle custom instructions & muxes configuration as part of the same request
- Adds a PUT `/workspaces/:workspace_name`
  - this is how you rename a workspace now
  - this can also handle updating custom instructions & muxes configuration

**ToDo**:
- GET `/workspaces/:workspace_name` or maybe (`/workspaces/:workspace_name`, I'm not sure yet) to get the configuration for a workspace 