### PR TITLE
Fix copilot secret unredaction

### DIFF
--- a/src/codegate/pipeline/output.py
+++ b/src/codegate/pipeline/output.py
@@ -170,8 +170,9 @@ class OutputPipelineInstance:
         finally:
             # NOTE: Don't use await in finally block, it will break the stream
             # Don't flush the buffer if we assume we'll call the pipeline again
-            if cleanup_sensitive is False and finish_stream:
-                self._record_to_db()
+            if cleanup_sensitive is False:
+                if finish_stream:
+                    self._record_to_db()
                 return
 
             # Process any remaining content in buffer when stream ends


### PR DESCRIPTION
The copilot provider always sends `cleanup_sensitive` set to `False` as it
manages the context itself. On streams where `finish_stream` was set to
`False` as well, we would have yielded the rest of the context buffer though
which would break secret unredaction.

To reproduce, ask Copilot to make a simple modification in a file
containing secrets so that it's forced to print the secrets back to you.
