### PR TITLE
Don't add the system prompt warning about secrets in the Secrets step

### DIFF
--- a/src/codegate/pipeline/secrets/secrets.py
+++ b/src/codegate/pipeline/secrets/secrets.py
@@ -1,12 +1,9 @@
-import itertools
 import re
 from abc import abstractmethod
 from typing import Any, List, Optional, Tuple
 
-import pydantic
 import structlog
 
-from codegate.config import Config
 from codegate.db.models import AlertSeverity
 from codegate.extract_snippets.factory import MessageCodeExtractorFactory
 from codegate.pipeline.base import (
@@ -18,7 +15,6 @@ from codegate.pipeline.base import (
 from codegate.pipeline.output import OutputPipelineContext, OutputPipelineStep
 from codegate.pipeline.secrets.manager import SecretsManager
 from codegate.pipeline.secrets.signatures import CodegateSignatures, Match
-
 
 logger = structlog.get_logger("codegate")
 
@@ -360,8 +356,6 @@ class CodegateSecrets(PipelineStep):
         context.secrets_found = total_redacted > 0
         logger.info(f"Total secrets redacted since last assistant message: {total_redacted}")
         context.metadata["redacted_secrets_count"] = total_redacted
-        if total_redacted > 0:
-            new_request.add_system_prompt(Config.get_config().prompts.secrets_redacted)
         return new_request
 
 


### PR DESCRIPTION
This didn't matter when we were using the FIM normalizer as we would have dropped the messages including the system message later, but since we are passing the messages verbatim, let's not add the system message when obfuscating secrets. Adding it means that the message is leaked to the FIM tab-completion.