### PR TITLE
Allow creating database connection wrapper without a singleton

### DIFF
--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -97,8 +97,8 @@ class DbCodeGate:
 
 
 class DbRecorder(DbCodeGate):
-    def __init__(self, sqlite_path: Optional[str] = None):
-        super().__init__(sqlite_path)
+    def __init__(self, sqlite_path: Optional[str] = None, *args, **kwargs):
+        super().__init__(sqlite_path, *args, **kwargs)
 
     async def _execute_update_pydantic_model(
         self, model: BaseModel, sql_command: TextClause, should_raise: bool = False
@@ -525,8 +525,8 @@ class DbRecorder(DbCodeGate):
 
 
 class DbReader(DbCodeGate):
-    def __init__(self, sqlite_path: Optional[str] = None):
-        super().__init__(sqlite_path)
+    def __init__(self, sqlite_path: Optional[str] = None, *args, **kwargs):
+        super().__init__(sqlite_path, *args, **kwargs)
 
     async def _dump_result_to_pydantic_model(
         self, model_type: Type[BaseModel], result: CursorResult

--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -61,11 +61,17 @@ class DbCodeGate:
     _instance = None
 
     def __new__(cls, *args, **kwargs):
+        # The _no_singleton flag is used to create a new instance of the class
+        # It should only be used for testing
+        if "_no_singleton" in kwargs and kwargs["_no_singleton"]:
+            kwargs.pop("_no_singleton")
+            return super().__new__(cls, *args, **kwargs)
+
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
 
-    def __init__(self, sqlite_path: Optional[str] = None):
+    def __init__(self, sqlite_path: Optional[str] = None, **kwargs):
         if not hasattr(self, "_initialized"):
             # Ensure __init__ is only executed once
             self._initialized = True


### PR DESCRIPTION
The idea is that one would be able to pass the `_no_singleton` boolean
flag to the class and if so, the class would be returned without
creating a singleton.

This is handy for testing, since it would allow for several connections
to be open in parallel to different database paths, which indeed is a
testing scenario.

```
>>> from codegate.db.connection import DbCodeGate
>>> dbc = DbCodeGate(_no_singleton=True)
>>> print(dbc)
<codegate.db.connection.DbCodeGate object at 0x7f9a0f067650>
>>> dbc2 = DbCodeGate(_no_singleton=True)
>>> print(dbc2)
<codegate.db.connection.DbCodeGate object at 0x7f9a0daad1f0>
>>> dbc3 = DbCodeGate()
>>> print(dbc3)
<codegate.db.connection.DbCodeGate object at 0x7f9a0f065190>
>>> dbc4 = DbCodeGate()
>>> print(dbc4)
<codegate.db.connection.DbCodeGate object at 0x7f9a0f065190>
```

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
