### PR TITLE
Use ARM runners for building ARM container image

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   docker-image:
     name: Check docker image build
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     env:
       IMAGE_NAME: stacklok/codegate
       IMAGE_TAG: dev


### PR DESCRIPTION
This should hopefully speed up image building.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
