### PR TITLE
Add a copilot-specific FIM class instead of adding extra fields to Le…

### DIFF
--- a/src/codegate/providers/copilot/pipeline.py
+++ b/src/codegate/providers/copilot/pipeline.py
@@ -12,7 +12,7 @@ from codegate.providers.normalizer.completion import CompletionNormalizer
 from codegate.types.openai import (
     ChatCompletionRequest,
     ChoiceDelta,
-    LegacyCompletionRequest,
+    CopilotCompletionRequest,
     MessageDelta,
     StreamingChatCompletion,
 )
@@ -162,7 +162,7 @@ class CopilotFimNormalizer:
     def __init__(self):
         self._completion_normalizer = CompletionNormalizer()
 
-    def normalize(self, body: bytes) -> LegacyCompletionRequest:
+    def normalize(self, body: bytes) -> CopilotCompletionRequest:
         # Copilot FIM sometimes doesn't set the model field
         # to set a sensible default value, we first try to load the JSON
         # and then set the model field if it's missing, then we call model_validate
@@ -171,13 +171,13 @@ class CopilotFimNormalizer:
             data: Dict[str, Any] = json.loads(body)
         except json.JSONDecodeError:
             # If JSON is invalid, let Pydantic handle the error with a nice message
-            return LegacyCompletionRequest.model_validate_json(body)
+            return CopilotCompletionRequest.model_validate_json(body)
 
         # Add model field if missing
         if 'model' not in data:
             data['model'] = 'gpt-4o-mini'
 
-        return LegacyCompletionRequest.model_validate(data)
+        return CopilotCompletionRequest.model_validate(data)
 
     def denormalize(self, request_from_pipeline: ChatCompletionRequest) -> bytes:
         return request_from_pipeline.model_dump_json(

--- a/src/codegate/types/openai/__init__.py
+++ b/src/codegate/types/openai/__init__.py
@@ -63,3 +63,7 @@ from ._legacy_models import (
     LegacyMessage,
     LegacyCompletion,
 )
+
+from ._copilot import (
+    CopilotCompletionRequest
+)

--- a/src/codegate/types/openai/_copilot.py
+++ b/src/codegate/types/openai/_copilot.py
@@ -1,0 +1,8 @@
+from typing import Any, Dict
+
+from ._legacy_models import LegacyCompletionRequest
+
+
+class CopilotCompletionRequest(LegacyCompletionRequest):
+    nwo: str | None = None
+    extra: Dict[str, Any] | None = None

--- a/src/codegate/types/openai/_legacy_models.py
+++ b/src/codegate/types/openai/_legacy_models.py
@@ -2,17 +2,17 @@ from typing import (
     Any,
     Iterable,
     List,
-    Literal, Dict,
+    Literal,
 )
 
 import pydantic
 
+from ._request_models import (
+    Message,
+    StreamOption,
+)
 from ._response_models import (
     Usage,
-)
-from ._request_models import (
-    StreamOption,
-    Message,
 )
 
 
@@ -35,8 +35,6 @@ class LegacyCompletionRequest(pydantic.BaseModel):
     temperature: float | None = 1.0
     top_p: float | None = 1.0
     user: str | None = None
-    nwo: str | None = None # Copilot specific
-    extra: Dict[str, Any] | None = None # Copilot specific
 
     def get_stream(self) -> bool:
         return self.stream


### PR DESCRIPTION
…gacyCompletionRequest

Adding the copilot specific fields had the unintended side-effect of passing them to completion functions when we passed them as `**kwargs`.

In particular, this was breaking llamacpp FIM.

Instead, let's create another, copilot specific class that inherits from LegacyCompletionRequest.