### PR TITLE
Pass fewer snippets to suspicious commands

### DIFF
--- a/src/codegate/pipeline/comment/output.py
+++ b/src/codegate/pipeline/comment/output.py
@@ -12,8 +12,7 @@ from codegate.extract_snippets.message_extractor import (
 )
 from codegate.pipeline.base import PipelineContext
 from codegate.pipeline.output import OutputPipelineContext, OutputPipelineStep
-
-# from codegate.pipeline.suspicious_commands.suspicious_commands import check_suspicious_code
+from codegate.pipeline.suspicious_commands.suspicious_commands import check_suspicious_code
 from codegate.storage import StorageEngine
 from codegate.utils.package_extractor import PackageExtractor
 
@@ -53,10 +52,15 @@ class CodeCommentStep(OutputPipelineStep):
         """Create a comment for a snippet"""
         comment = ""
 
-        # Remove this for now. We need to find a better place for it.
-        # comment, is_suspicious = await check_suspicious_code(snippet.code, snippet.language)
-        # if is_suspicious:
-        #     comment += comment
+        if (
+            snippet.filepath is None
+            and snippet.file_extension is None
+            and "filepath" not in snippet.code
+            and "existing code" not in snippet.code
+        ):
+            new_comment, is_suspicious = await check_suspicious_code(snippet.code, snippet.language)
+            if is_suspicious:
+                comment += new_comment
 
         snippet.libraries = PackageExtractor.extract_packages(snippet.code, snippet.language)
 


### PR DESCRIPTION
This re-enables suspicious commands. Closes #1038 

The main difference is in these lines https://github.com/stacklok/codegate/pull/1151/files#diff-0658dbd5db53af1b59ad53ac8ce9dc0ba40042abea62cce7f6b04eebf3fa4cffR56-R59

It should no longer mess with edits mode on copilot. Also, it should no longer apply if the language is any of
```
        "python",
        "javascript",
        "typescript",
        "go",
        "rust",
        "java",
```
I see the secrets warning occasionally, as per https://github.com/stacklok/codegate/issues/1038, but it is not going through the suspicious commands code. 

I tested this quite a lot on co-pilot, but not the other assistants.  The accuracy for unfamiliar commands needs improvement.