### PR TITLE
Don't leak the PII system message into the FIM output

### DIFF
--- a/src/codegate/pipeline/base.py
+++ b/src/codegate/pipeline/base.py
@@ -52,8 +52,12 @@ class PipelineContext:
     input_request: Optional[Prompt] = field(default_factory=lambda: None)
     output_responses: List[Output] = field(default_factory=list)
     shortcut_response: bool = False
+    # TODO(jakub): Remove these flags, they couple the steps to the context too much
+    # instead we should be using the metadata field scoped to the step to store anything
+    # the step wants
     bad_packages_found: bool = False
     secrets_found: bool = False
+    pii_found: bool = False
     client: ClientType = ClientType.GENERIC
 
     def add_alert(

--- a/src/codegate/pipeline/pii/pii.py
+++ b/src/codegate/pipeline/pii/pii.py
@@ -105,10 +105,12 @@ class CodegatePii(PipelineStep):
         context.metadata["redacted_text"] = last_redacted_text
 
         if total_pii_found > 0:
+            # TODO(jakub): Storing per-step booleans is a temporary hack. We should
+            # instead let the steps store the system message contents they want to
+            # have added and then have a separate step that only adds them without
+            # passing around bools in the context
+            context.pii_found = True
             context.metadata["pii_manager"] = self.pii_manager
-            request.add_system_prompt(
-                Config.get_config().prompts.pii_redacted,
-            )
 
         logger.debug(f"Redacted text: {last_redacted_text}")
 


### PR DESCRIPTION
Applies to this branch only as it actually corectly handles the messages. Similar to how we handle secrets, also PII adds a system prompt that would be added to the messages and might affect the FIM output where it might suggest a warning about leaked FIM.

I added some TODOs into the code because I don't love how the code is structured but that change should be done in a separate work on main, not in a topic branch.