### PR TITLE
fix: handle dict type trigger_string in alert deduplication for Cline

### DIFF
--- a/src/codegate/api/v1_processing.py
+++ b/src/codegate/api/v1_processing.py
@@ -516,8 +516,21 @@ async def remove_duplicate_alerts(alerts: List[v1_models.Alert]) -> List[v1_mode
         alerts, key=lambda x: x.timestamp, reverse=True
     ):  # Sort alerts by timestamp descending
 
-        # Extract trigger string content until "Context"
-        trigger_string_content = alert.trigger_string.split("Context")[0]
+        # Handle trigger_string based on its type
+        trigger_string_content = ""
+        if isinstance(alert.trigger_string, dict):
+            # If it's a dict, use relevant fields for deduplication
+            trigger_string_content = json.dumps({
+                'name': alert.trigger_string.get('name'),
+                'type': alert.trigger_string.get('type'),
+                'status': alert.trigger_string.get('status')
+            })
+        elif isinstance(alert.trigger_string, str):
+            # If it's a string, use the part before "Context" if it exists
+            trigger_string_content = alert.trigger_string.split("Context")[0]
+        else:
+            # For any other case, convert to string
+            trigger_string_content = str(alert.trigger_string)
 
         key = (
             alert.code_snippet,

--- a/src/codegate/api/v1_processing.py
+++ b/src/codegate/api/v1_processing.py
@@ -520,11 +520,13 @@ async def remove_duplicate_alerts(alerts: List[v1_models.Alert]) -> List[v1_mode
         trigger_string_content = ""
         if isinstance(alert.trigger_string, dict):
             # If it's a dict, use relevant fields for deduplication
-            trigger_string_content = json.dumps({
-                'name': alert.trigger_string.get('name'),
-                'type': alert.trigger_string.get('type'),
-                'status': alert.trigger_string.get('status')
-            })
+            trigger_string_content = json.dumps(
+                {
+                    "name": alert.trigger_string.get("name"),
+                    "type": alert.trigger_string.get("type"),
+                    "status": alert.trigger_string.get("status"),
+                }
+            )
         elif isinstance(alert.trigger_string, str):
             # If it's a string, use the part before "Context" if it exists
             trigger_string_content = alert.trigger_string.split("Context")[0]


### PR DESCRIPTION
The alert deduplication logic was failing when trigger_string was a dictionary, causing an AttributeError when trying to call split() on it. Updated the code to:

- Check trigger_string type before processing
- Handle dictionary case by creating a consistent JSON string from relevant fields
- Maintain existing string handling for backwards compatibility
- Add fallback for other types by converting to string

This ensures alerts are properly deduplicated regardless of trigger_string format.

Fixes: #1162