### PR TITLE
Add support for Gemini

### DIFF
--- a/src/codegate/db/models.py
+++ b/src/codegate/db/models.py
@@ -134,6 +134,7 @@ class ProviderType(str, Enum):
     lm_studio = "lm_studio"
     llamacpp = "llamacpp"
     openrouter = "openrouter"
+    gemini = "gemini"
 
 
 class IntermediatePromptWithOutputUsageAlerts(BaseModel):

--- a/src/codegate/muxing/adapter.py
+++ b/src/codegate/muxing/adapter.py
@@ -39,6 +39,9 @@ class BodyAdapter:
             return urljoin(model_route.endpoint.endpoint, "/v1")
         if model_route.endpoint.provider_type == db_models.ProviderType.openrouter:
             return urljoin(model_route.endpoint.endpoint, "/api/v1")
+        if model_route.endpoint.provider_type == db_models.ProviderType.gemini:
+            # Gemini API uses /v1beta/openai as the base URL
+            return urljoin(model_route.endpoint.endpoint, "/v1beta/openai")
         return model_route.endpoint.endpoint
 
     def set_destination_info(self, model_route: rulematcher.ModelRoute, data: dict) -> dict:
@@ -209,6 +212,8 @@ class ChatStreamChunkFormatter(StreamChunkFormatter):
             db_models.ProviderType.openrouter: self._format_openai,
             # VLLM is a dialect of OpenAI
             db_models.ProviderType.vllm: self._format_openai,
+            # Gemini provider emits OpenAI-compatible chunks
+            db_models.ProviderType.gemini: self._format_openai,
         }
 
     def _format_ollama(self, chunk: str) -> str:
@@ -245,6 +250,8 @@ class FimStreamChunkFormatter(StreamChunkFormatter):
             # VLLM is a dialect of OpenAI
             db_models.ProviderType.vllm: self._format_openai,
             db_models.ProviderType.anthropic: self._format_antropic,
+            # Gemini provider emits OpenAI-compatible chunks
+            db_models.ProviderType.gemini: self._format_openai,
         }
 
     def _format_ollama(self, chunk: str) -> str:

--- a/src/codegate/providers/crud/crud.py
+++ b/src/codegate/providers/crud/crud.py
@@ -453,6 +453,7 @@ def provider_default_endpoints(provider_type: str) -> str:
     defaults = {
         "openai": "https://api.openai.com",
         "anthropic": "https://api.anthropic.com",
+        "gemini": "https://generativelanguage.googleapis.com",
     }
 
     # If we have a default, we return it

--- a/src/codegate/providers/gemini/__init__.py
+++ b/src/codegate/providers/gemini/__init__.py
@@ -1,0 +1,3 @@
+"""
+Gemini provider for CodeGate.
+"""

--- a/src/codegate/providers/gemini/adapter.py
+++ b/src/codegate/providers/gemini/adapter.py
@@ -1,0 +1,141 @@
+from typing import Any, Dict, Optional
+
+import structlog
+from litellm import ChatCompletionRequest
+
+from codegate.providers.litellmshim import sse_stream_generator
+from codegate.providers.litellmshim.adapter import (
+    BaseAdapter,
+    LiteLLMAdapterInputNormalizer,
+    LiteLLMAdapterOutputNormalizer,
+)
+
+logger = structlog.get_logger("codegate")
+
+
+class GeminiAdapter(BaseAdapter):
+    """
+    Adapter for Gemini API to translate between Gemini's format and OpenAI's format.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(sse_stream_generator)
+
+    def translate_completion_input_params(self, kwargs) -> Optional[ChatCompletionRequest]:
+        """
+        Translate Gemini API parameters to OpenAI format.
+
+        Gemini API uses a similar format to OpenAI, but with some differences:
+        - 'contents' instead of 'messages'
+        - Different role names
+        - Different parameter names for temperature, etc.
+        """
+        # Make a copy to avoid modifying the original
+        translated_params = dict(kwargs)
+
+        # Handle Gemini-specific parameters
+        if "contents" in translated_params:
+            # Convert Gemini 'contents' to OpenAI 'messages'
+            contents = translated_params.pop("contents")
+            messages = []
+
+            for content in contents:
+                role = content.get("role", "user")
+                # Map Gemini roles to OpenAI roles
+                if role == "model":
+                    role = "assistant"
+
+                message = {
+                    "role": role,
+                    "content": content.get("parts", [{"text": ""}])[0].get("text", ""),
+                }
+                messages.append(message)
+
+            translated_params["messages"] = messages
+
+        # Map other parameters
+        if "temperature" in translated_params:
+            # Temperature is the same in both APIs
+            pass
+
+        if "topP" in translated_params:
+            translated_params["top_p"] = translated_params.pop("topP")
+
+        if "topK" in translated_params:
+            translated_params["top_k"] = translated_params.pop("topK")
+
+        if "maxOutputTokens" in translated_params:
+            translated_params["max_tokens"] = translated_params.pop("maxOutputTokens")
+
+        # Check if we're using the OpenAI-compatible endpoint
+        is_openai_compatible = False
+        if (
+            "_is_openai_compatible" in translated_params
+            and translated_params["_is_openai_compatible"]
+        ):
+            is_openai_compatible = True
+            # Remove the custom field to avoid sending it to the API
+            translated_params.pop("_is_openai_compatible")
+        elif (
+            "base_url" in translated_params
+            and translated_params["base_url"]
+            and "v1beta/openai" in translated_params["base_url"]
+        ):
+            is_openai_compatible = True
+
+        # Apply the appropriate prefix based on the endpoint
+        if "model" in translated_params:
+            model_in_request = translated_params["model"]
+            if is_openai_compatible:
+                # For OpenAI-compatible endpoint, use 'openai/' prefix
+                if not model_in_request.startswith("openai/"):
+                    translated_params["model"] = f"openai/{model_in_request}"
+                    logger.debug(
+                        "Using OpenAI-compatible endpoint, prefixed model name with 'openai/': %s",
+                        translated_params["model"],
+                    )
+            else:
+                # For native Gemini API, use 'gemini/' prefix
+                if not model_in_request.startswith("gemini/"):
+                    translated_params["model"] = f"gemini/{model_in_request}"
+                    logger.debug(
+                        "Using native Gemini API, prefixed model name with 'gemini/': %s",
+                        translated_params["model"],
+                    )
+
+        return ChatCompletionRequest(**translated_params)
+
+    def translate_completion_output_params(self, response: Any) -> Dict:
+        """
+        Translate OpenAI format response to Gemini format.
+        """
+        # For non-streaming responses, we can just return the response as is
+        # LiteLLM should handle the conversion
+        return response
+
+    def translate_completion_output_params_streaming(self, completion_stream: Any) -> Any:
+        """
+        Translate streaming response from OpenAI format to Gemini format.
+        """
+        # For streaming, we can just return the stream as is
+        # The stream generator will handle the conversion
+        return completion_stream
+
+
+class GeminiInputNormalizer(LiteLLMAdapterInputNormalizer):
+    """
+    Normalizer for Gemini API input.
+    """
+
+    def __init__(self):
+        self.adapter = GeminiAdapter()
+        super().__init__(self.adapter)
+
+
+class GeminiOutputNormalizer(LiteLLMAdapterOutputNormalizer):
+    """
+    Normalizer for Gemini API output.
+    """
+
+    def __init__(self):
+        super().__init__(GeminiAdapter())

--- a/src/codegate/providers/gemini/completion_handler.py
+++ b/src/codegate/providers/gemini/completion_handler.py
@@ -1,0 +1,71 @@
+from typing import AsyncIterator, Optional, Union
+
+import structlog
+from litellm import ChatCompletionRequest, ModelResponse
+
+from codegate.providers.litellmshim import LiteLLmShim
+
+logger = structlog.get_logger("codegate")
+
+
+class GeminiCompletion(LiteLLmShim):
+    """
+    GeminiCompletion used by the Gemini provider to execute completions.
+
+    This class extends LiteLLmShim to handle Gemini-specific completion logic.
+    """
+
+    async def execute_completion(
+        self,
+        request: ChatCompletionRequest,
+        base_url: Optional[str],
+        api_key: Optional[str],
+        stream: bool = False,
+        is_fim_request: bool = False,
+    ) -> Union[ModelResponse, AsyncIterator[ModelResponse]]:
+        """
+        Execute the completion request with LiteLLM's API.
+
+        Ensures the model name is prefixed with the appropriate prefix to route to Google's API:
+        - 'openai/' for the OpenAI-compatible endpoint (v1beta/openai)
+        - 'gemini/' for the native Gemini API
+        """
+        model_in_request = request["model"]
+
+        # Check if we're using the OpenAI-compatible endpoint
+        is_openai_compatible = False
+        if "_is_openai_compatible" in request and request["_is_openai_compatible"]:
+            is_openai_compatible = True
+        elif base_url and "v1beta/openai" in base_url:
+            is_openai_compatible = True
+
+        # Apply the appropriate prefix based on the endpoint
+        if is_openai_compatible:
+            # For OpenAI-compatible endpoint, use 'openai/' prefix
+            if not model_in_request.startswith("openai/"):
+                request["model"] = f"openai/{model_in_request}"
+                logger.debug(
+                    "Using OpenAI-compatible endpoint, prefixed model name with 'openai/': %s",
+                    request["model"],
+                )
+        else:
+            # For native Gemini API, use 'gemini/' prefix
+            if not model_in_request.startswith("gemini/"):
+                request["model"] = f"gemini/{model_in_request}"
+                logger.debug(
+                    "Using native Gemini API, prefixed model name with 'gemini/': %s",
+                    request["model"],
+                )
+
+        # Set the API key and base URL
+        request["api_key"] = api_key
+        request["base_url"] = base_url
+
+        # Execute the completion
+        return await super().execute_completion(
+            request=request,
+            api_key=api_key,
+            stream=stream,
+            is_fim_request=is_fim_request,
+            base_url=base_url,
+        )

--- a/src/codegate/providers/gemini/provider.py
+++ b/src/codegate/providers/gemini/provider.py
@@ -1,0 +1,207 @@
+import json
+from typing import List
+
+import httpx
+import structlog
+from fastapi import Header, HTTPException, Request
+
+from codegate.clients.clients import ClientType
+from codegate.clients.detector import DetectClient
+from codegate.pipeline.factory import PipelineFactory
+from codegate.providers.base import BaseProvider, ModelFetchError
+from codegate.providers.fim_analyzer import FIMAnalyzer
+from codegate.providers.gemini.adapter import GeminiInputNormalizer, GeminiOutputNormalizer
+from codegate.providers.gemini.completion_handler import GeminiCompletion
+from codegate.providers.litellmshim import sse_stream_generator
+
+logger = structlog.get_logger("codegate")
+
+
+class GeminiProvider(BaseProvider):
+    """
+    Gemini provider for CodeGate.
+
+    This provider implements the Google Gemini API interface.
+    """
+
+    def __init__(
+        self,
+        pipeline_factory: PipelineFactory,
+    ):
+        completion_handler = GeminiCompletion(stream_generator=sse_stream_generator)
+        super().__init__(
+            GeminiInputNormalizer(),
+            GeminiOutputNormalizer(),
+            completion_handler,
+            pipeline_factory,
+        )
+
+    @property
+    def provider_route_name(self) -> str:
+        return "gemini"
+
+    def models(self, endpoint: str = None, api_key: str = None) -> List[str]:
+        """
+        Fetch available models from the Gemini API.
+
+        The Gemini API uses a different endpoint structure than OpenAI.
+        """
+        headers = {
+            "Content-Type": "application/json",
+        }
+
+        if api_key:
+            headers["x-goog-api-key"] = api_key
+
+        if not endpoint:
+            endpoint = "https://generativelanguage.googleapis.com"
+
+        try:
+            resp = httpx.get(
+                f"{endpoint}/v1/models",
+                headers=headers,
+            )
+
+            if resp.status_code != 200:
+                raise ModelFetchError(f"Failed to fetch models from Gemini API: {resp.text}")
+
+            respjson = resp.json()
+
+            # Filter for only generative models
+            return [
+                model["name"].split("/")[-1]
+                for model in respjson.get("models", [])
+                if "generateContent" in model.get("supportedGenerationMethods", [])
+            ]
+        except Exception as e:
+            logger.error(f"Error fetching Gemini models: {str(e)}")
+            raise ModelFetchError(f"Failed to fetch models from Gemini API: {str(e)}")
+
+    async def process_request(
+        self,
+        data: dict,
+        api_key: str,
+        is_fim_request: bool,
+        client_type: ClientType,
+    ):
+        """
+        Process a request to the Gemini API.
+        """
+        try:
+            stream = await self.complete(data, api_key, is_fim_request, client_type)
+        except Exception as e:
+            # Check if we have a status code there
+            if hasattr(e, "status_code"):
+                logger.exception("Error in GeminiProvider completion")
+                raise HTTPException(status_code=e.status_code, detail=str(e))
+            else:
+                # Just continue raising the exception
+                raise e
+        return self._completion_handler.create_response(stream, client_type)
+
+    def _setup_routes(self):
+        """
+        Set up the routes for the Gemini API.
+
+        Gemini API has two main endpoints:
+        - /generateContent: For generating content
+        - /chat/completions: For compatibility with OpenAI-style clients
+        """
+
+        @self.router.post(f"/{self.provider_route_name}/models/{{model}}:generateContent")
+        @self.router.post(f"/{self.provider_route_name}/models/{{model}}:generateContent")
+        @self.router.post(f"/{self.provider_route_name}/models/{{model}}:streamGenerateContent")
+        @self.router.post(f"/{self.provider_route_name}/models/{{model}}:streamGenerateContent")
+        @self.router.post(f"/{self.provider_route_name}/v1/models/{{model}}:generateContent")
+        @self.router.post(f"/{self.provider_route_name}/v1beta/models/{{model}}:generateContent")
+        @self.router.post(f"/{self.provider_route_name}/v1/models/{{model}}:streamGenerateContent")
+        @self.router.post(
+            f"/{self.provider_route_name}/v1beta/models/{{model}}:streamGenerateContent"
+        )
+        @DetectClient()
+        async def generate_content(
+            request: Request,
+            model: str,
+            x_goog_api_key: str = Header(None),
+        ):
+            """
+            Handle requests to the native Gemini API endpoint.
+            """
+            api_key = x_goog_api_key
+
+            # If no header is provided, check for key query parameter
+            if not api_key:
+                key_param = request.query_params.get("key")
+                if key_param:
+                    api_key = key_param
+
+            if not api_key:
+                raise HTTPException(
+                    status_code=401, detail="No API key provided in header or query parameter"
+                )
+
+            body = await request.body()
+            data = json.loads(body)
+
+            # Add the model to the data
+            data["model"] = model
+
+            # Add a custom field to indicate this is NOT the OpenAI-compatible endpoint
+            data["_is_openai_compatible"] = False
+
+            is_fim_request = FIMAnalyzer.is_fim_request(request.url.path, data)
+
+            return await self.process_request(
+                data,
+                api_key,
+                is_fim_request,
+                request.state.detected_client,
+            )
+
+        @self.router.post(f"/{self.provider_route_name}/chat/completions")
+        @self.router.post(f"/{self.provider_route_name}/v1/chat/completions")
+        @self.router.post(f"/{self.provider_route_name}/v1beta/openai/chat/completions")
+        @DetectClient()
+        async def chat_completions(
+            request: Request,
+            authorization: str = Header(None),
+        ):
+            """
+            Handle requests to the OpenAI-compatible endpoint.
+
+            This allows clients that use the OpenAI API to work with Gemini.
+            """
+            api_key = None
+
+            # Check for authorization header
+            if authorization:
+                if not authorization.startswith("Bearer "):
+                    raise HTTPException(status_code=401, detail="Invalid authorization header")
+                api_key = authorization.split(" ")[1]
+
+            # If no authorization header, check for key query parameter
+            if not api_key:
+                key_param = request.query_params.get("key")
+                if key_param:
+                    api_key = key_param
+
+            # If still no API key, raise an error
+            if not api_key:
+                raise HTTPException(
+                    status_code=401, detail="No API key provided in header or query parameter"
+                )
+
+            body = await request.body()
+            data = json.loads(body)
+
+            # Add a custom field to indicate this is the OpenAI-compatible endpoint
+            data["_is_openai_compatible"] = "v1beta/openai" in request.url.path
+
+            is_fim_request = FIMAnalyzer.is_fim_request(request.url.path, data)
+
+            return await self.process_request(
+                data,
+                api_key,
+                is_fim_request,
+                request.state.detected_client,
+            )

--- a/src/codegate/server.py
+++ b/src/codegate/server.py
@@ -14,6 +14,7 @@ from codegate.db.models import ProviderType
 from codegate.muxing.router import MuxRouter
 from codegate.pipeline.factory import PipelineFactory
 from codegate.providers.anthropic.provider import AnthropicProvider
+from codegate.providers.gemini.provider import GeminiProvider
 from codegate.providers.llamacpp.provider import LlamaCppProvider
 from codegate.providers.lm_studio.provider import LmStudioProvider
 from codegate.providers.ollama.provider import OllamaProvider
@@ -107,6 +108,12 @@ def init_app(pipeline_factory: PipelineFactory) -> CodeGateServer:
     registry.add_provider(
         ProviderType.lm_studio,
         LmStudioProvider(
+            pipeline_factory,
+        ),
+    )
+    registry.add_provider(
+        ProviderType.gemini,
+        GeminiProvider(
             pipeline_factory,
         ),
     )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -108,7 +108,7 @@ def test_provider_registration(mock_registry, mock_secrets_mgr, mock_pipeline_fa
     # Verify all providers were registered
     registry_instance = mock_registry.return_value
     assert (
-        registry_instance.add_provider.call_count == 7
+        registry_instance.add_provider.call_count == 8
     )  # openai, anthropic, llamacpp, vllm, ollama, lm_studio, openrouter
 
     # Verify specific providers were registered


### PR DESCRIPTION
This adds support for the two types of Gemini endpoints:

- Standard API
- OpenAI-compatible

NOTE: The OpenAI-compatible endpoints are working in both standalone and
muxing scenarios. I'm still trying to get the standard-gemini endpoints
working.

For now, one can test the Gemini integration in Continue as follows:

```
   {
      "title": "Gemini 2.0 Flash",
      "provider": "openai",
      "model": "gemini-2.0-flash",
      "apiBase": "http://127.0.0.1:8989/gemini/v1beta/openai",
      "apiKey": "MY_API_KEY"
    }
```

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
