### PR TITLE
Use glob patterns in muxing rules

### DIFF
--- a/src/codegate/muxing/rulematcher.py
+++ b/src/codegate/muxing/rulematcher.py
@@ -1,4 +1,5 @@
 import copy
+import fnmatch
 from abc import ABC, abstractmethod
 from asyncio import Lock
 from typing import Dict, List, Optional
@@ -116,16 +117,16 @@ class FileMuxingRuleMatcher(MuxingRuleMatcher):
     def _is_matcher_in_filenames(self, detected_client: ClientType, data: dict) -> bool:
         """
         Check if the matcher is in the request filenames.
+        The matcher is treated as a glob pattern and matched against the filenames.
         """
         # Empty matcher_blob means we match everything
         if not self._mux_rule.matcher:
             return True
         filenames_to_match = self._extract_request_filenames(detected_client, data)
-        # _mux_rule.matcher can be a filename or a file extension. We match if any of the filenames
-        # match the rule.
+        # _mux_rule.matcher is a glob pattern. We match if any of the filenames
+        # match the pattern.
         is_filename_match = any(
-            self._mux_rule.matcher == filename or filename.endswith(self._mux_rule.matcher)
-            for filename in filenames_to_match
+            fnmatch.fnmatch(filename, self._mux_rule.matcher) for filename in filenames_to_match
         )
         return is_filename_match
 

--- a/tests/muxing/test_rulematcher.py
+++ b/tests/muxing/test_rulematcher.py
@@ -51,13 +51,13 @@ def test_catch_all(matcher_blob, thing_to_match):
     [
         (None, [], True),  # Empty filenames and no blob
         (None, ["main.py"], True),  # Empty blob should match
-        (".py", ["main.py"], True),  # Extension match
+        ("*.py", ["main.py"], True),  # Extension match
         ("main.py", ["main.py"], True),  # Full name match
-        (".py", ["main.py", "test.py"], True),  # Extension match
+        ("*.py", ["main.py", "test.py"], True),  # Extension match
         ("main.py", ["main.py", "test.py"], True),  # Full name match
         ("main.py", ["test.py"], False),  # Full name no match
-        (".js", ["main.py", "test.py"], False),  # Extension no match
-        (".ts", ["main.tsx", "test.tsx"], False),  # Extension no match
+        ("*.js", ["main.py", "test.py"], False),  # Extension no match
+        ("*.ts", ["main.tsx", "test.tsx"], False),  # Extension no match
     ],
 )
 def test_file_matcher(
@@ -89,13 +89,13 @@ def test_file_matcher(
     [
         (None, [], True),  # Empty filenames and no blob
         (None, ["main.py"], True),  # Empty blob should match
-        (".py", ["main.py"], True),  # Extension match
+        ("*.py", ["main.py"], True),  # Extension match
         ("main.py", ["main.py"], True),  # Full name match
-        (".py", ["main.py", "test.py"], True),  # Extension match
+        ("*.py", ["main.py", "test.py"], True),  # Extension match
         ("main.py", ["main.py", "test.py"], True),  # Full name match
         ("main.py", ["test.py"], False),  # Full name no match
-        (".js", ["main.py", "test.py"], False),  # Extension no match
-        (".ts", ["main.tsx", "test.tsx"], False),  # Extension no match
+        ("*.js", ["main.py", "test.py"], False),  # Extension no match
+        ("*.ts", ["main.tsx", "test.tsx"], False),  # Extension no match
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
We were using a handcrafted logic to determine if it was an exact match or an extension match (sorry about that).

This PR replaces it for glob patterns