### PR TITLE
feat: filter messages by ID

### DIFF
--- a/src/codegate/api/v1.py
+++ b/src/codegate/api/v1.py
@@ -407,6 +407,7 @@ async def get_workspace_messages(
     workspace_name: str,
     page: int = Query(1, ge=1),
     page_size: int = Query(API_DEFAULT_PAGE_SIZE, ge=1, le=API_MAX_PAGE_SIZE),
+    filter_by_ids: Optional[List[str]] = Query(None),
 ) -> v1_models.PaginatedMessagesResponse:
     """Get messages for a workspace."""
     try:
@@ -422,7 +423,7 @@ async def get_workspace_messages(
 
     while len(fetched_messages) < page_size:
         messages_batch = await dbreader.get_prompts_with_output_alerts_usage_by_workspace_id(
-            ws.id, AlertSeverity.CRITICAL.value, page_size, offset
+            ws.id, AlertSeverity.CRITICAL.value, page_size, offset, filter_by_ids
         )
         if not messages_batch:
             break

--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -8,7 +8,7 @@ import structlog
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
 from pydantic import BaseModel
-from sqlalchemy import CursorResult, TextClause, event, text
+from sqlalchemy import CursorResult, TextClause, bindparam, event, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -605,40 +605,46 @@ class DbReader(DbCodeGate):
         """
         Get all prompts with their outputs, alerts and token usage by workspace_id.
         """
-        sql = text(
-            """
+
+        base_query = """
             SELECT
-                p.id as prompt_id, p.timestamp as prompt_timestamp, p.provider, p.request, p.type,
-                o.id as output_id, o.output, o.timestamp as output_timestamp, o.input_tokens, o.output_tokens, o.input_cost, o.output_cost,
-                a.id as alert_id, a.code_snippet, a.trigger_string, a.trigger_type, a.trigger_category, a.timestamp as alert_timestamp
+            p.id as prompt_id, p.timestamp as prompt_timestamp, p.provider, p.request, p.type,
+            o.id as output_id, o.output, o.timestamp as output_timestamp, o.input_tokens, o.output_tokens, o.input_cost, o.output_cost,
+            a.id as alert_id, a.code_snippet, a.trigger_string, a.trigger_type, a.trigger_category, a.timestamp as alert_timestamp
             FROM prompts p
             LEFT JOIN outputs o ON p.id = o.prompt_id
             LEFT JOIN alerts a ON p.id = a.prompt_id
             WHERE p.workspace_id = :workspace_id
-            """  # noqa: E501
-        )
-        conditions = {"workspace_id": workspace_id}
-        if trigger_category:
-            sql = text(sql.text + " AND a.trigger_category = :trigger_category")
-            conditions["trigger_category"] = trigger_category
+            AND (:trigger_category IS NULL OR a.trigger_category = :trigger_category)
+        """  # noqa: E501
 
         if filter_by_ids:
-            placeholders = ", ".join([":filter_by_id_" + str(i) for i in range(len(filter_by_ids))])
-            sql = text(sql.text + f" AND p.id IN ({placeholders})")
-            for i, filter_id in enumerate(filter_by_ids):
-                conditions[f"filter_by_id_{i}"] = filter_id
+            base_query += " AND p.id IN :filter_ids"
 
-        sql = text(
-            sql.text + " ORDER BY o.timestamp DESC, a.timestamp DESC LIMIT :limit OFFSET :offset"
-        )
-        conditions["limit"] = limit
-        conditions["offset"] = offset
+        base_query += """
+            ORDER BY o.timestamp DESC, a.timestamp DESC
+            LIMIT :limit OFFSET :offset
+        """
 
-        fetched_rows: List[IntermediatePromptWithOutputUsageAlerts] = (
-            await self._exec_select_conditions_to_pydantic(
-                IntermediatePromptWithOutputUsageAlerts, sql, conditions, should_raise=True
-            )
+        sql = text(base_query)
+
+        conditions = {
+            "workspace_id": workspace_id,
+            "trigger_category": trigger_category,
+            "limit": limit,
+            "offset": offset,
+        }
+
+        if filter_by_ids:
+            sql = sql.bindparams(bindparam("filter_ids", expanding=True))
+            conditions["filter_ids"] = filter_by_ids
+
+        fetched_rows: List[
+            IntermediatePromptWithOutputUsageAlerts
+        ] = await self._exec_select_conditions_to_pydantic(
+            IntermediatePromptWithOutputUsageAlerts, sql, conditions, should_raise=True
         )
+
         prompts_dict: Dict[str, GetPromptWithOutputsRow] = {}
         for row in fetched_rows:
             prompt_id = row.prompt_id

--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -8,7 +8,7 @@ import structlog
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
 from pydantic import BaseModel
-from sqlalchemy import CursorResult, TextClause, bindparam, event, text
+from sqlalchemy import CursorResult, TextClause, event, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -634,10 +634,10 @@ class DbReader(DbCodeGate):
         conditions["limit"] = limit
         conditions["offset"] = offset
 
-        fetched_rows: List[
-            IntermediatePromptWithOutputUsageAlerts
-        ] = await self._exec_select_conditions_to_pydantic(
-            IntermediatePromptWithOutputUsageAlerts, sql, conditions, should_raise=True
+        fetched_rows: List[IntermediatePromptWithOutputUsageAlerts] = (
+            await self._exec_select_conditions_to_pydantic(
+                IntermediatePromptWithOutputUsageAlerts, sql, conditions, should_raise=True
+            )
         )
         prompts_dict: Dict[str, GetPromptWithOutputsRow] = {}
         for row in fetched_rows:


### PR DESCRIPTION
While integrating the pagination changes in #1020 I realised that we need the ability to find specific messages for display in the UI. Previously we just filtered the entire set, but after adding pagination to this endpoint, that is no longer possible.

This PR adds a `filter_by_ids` param to `GET /v1/workspaces/:name/messages`, which accepts a list of IDs to filter by. I thought about `GET /v1/workspaces/:name/messages/:id` — but I think given the semi-complex logic of parsing disparate prompts & outputs and matching them to messages, this might be simpler, as well as allowing other opportunities to find specific messages and highlight them in the dashboard at a later point.

### Examples

Without filtering:

```
curl -s "http://localhost:8989/api/v1/workspaces/default/messages?page=1&page_size=2" | jq '[.data[].chat_id]'
[
  "aa85b6a5-423a-4cd0-a27f-51088b5fe30c",
  "5ac437ff-6b1c-4aa4-b276-d43bce33f28e"
]
```

Filtering by a single ID:
```
curl -s "http://localhost:8989/api/v1/workspaces/default/messages?page=1&page_size=2&filter_by_ids=aa85b6a5-423a-4cd0-a27f-51088b5fe30c" | jq '[.data[].chat_id]'
[
  "aa85b6a5-423a-4cd0-a27f-51088b5fe30c"
]
```

Filtering by multiple IDs:

```
curl -s "http://localhost:8989/api/v1/workspaces/default/messages?page=1&page_size=2&filter_by_ids=aa85b6a5-423a-4cd0-a27f-51088b5fe30c&filter_by_ids=5ac437ff-6b1c-4aa4-b276-d43bce33f28e" | jq '[.data[].chat_id]'
[
  "aa85b6a5-423a-4cd0-a27f-51088b5fe30c",
  "5ac437ff-6b1c-4aa4-b276-d43bce33f28e"
]
```

Filtering by non-existent ID:
```
curl -s "http://localhost:8989/api/v1/workspaces/default/messages?page=1&page_size=2&filter_by_ids=2
F2FDF94-429D-45E4-9D61-DFA4DB3E6D2F" | jq
{
  "data": [],
  "limit": 2,
  "offset": 0,
  "total": 63
}
```