### PR TITLE
fix: deduplicate response in paginated messages

### DIFF
--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -639,10 +639,10 @@ class DbReader(DbCodeGate):
             sql = sql.bindparams(bindparam("filter_ids", expanding=True))
             conditions["filter_ids"] = filter_by_ids
 
-        fetched_rows: List[
-            IntermediatePromptWithOutputUsageAlerts
-        ] = await self._exec_select_conditions_to_pydantic(
-            IntermediatePromptWithOutputUsageAlerts, sql, conditions, should_raise=True
+        fetched_rows: List[IntermediatePromptWithOutputUsageAlerts] = (
+            await self._exec_select_conditions_to_pydantic(
+                IntermediatePromptWithOutputUsageAlerts, sql, conditions, should_raise=True
+            )
         )
 
         prompts_dict: Dict[str, GetPromptWithOutputsRow] = {}


### PR DESCRIPTION
Fixes a minor nit in #1020 where multiple messages with the same `chat_id` were returned in the response from `/v1/workspaces/:name/messages`.

The root cause was in a while loop that continued to fetch more results until the number of records retrieved matched the page size. There was already a de-deduplication step in the wscrud method that retrieved the results, but due to the fixed size of the cursor, it wasn't able to fully de-duplicate the result.