### PR TITLE
Workaround for system messages that contain a list of dicts

### DIFF
--- a/src/codegate/pipeline/secrets/secrets.py
+++ b/src/codegate/pipeline/secrets/secrets.py
@@ -316,8 +316,17 @@ class CodegateSecrets(PipelineStep):
         # Process all messages
         for i, message in enumerate(new_request["messages"]):
             if "content" in message and message["content"]:
+                message_content = message["content"]
+
+                # cline with anthropic seems to be sending a list of dicts with type:text instead of
+                # a string
+                # this hack will not be needed once we access the native functions through an API
+                # (I tested this actually)
+                if isinstance(message_content, list) and "text" in message_content[0]:
+                    message_content = message_content[0]["text"]
+
                 redacted_content, secrets_matched = self._redact_message_content(
-                    message["content"], sensitive_data_manager, session_id, context
+                    message_content, sensitive_data_manager, session_id, context
                 )
                 new_request["messages"][i]["content"] = redacted_content
                 if i > last_assistant_idx:


### PR DESCRIPTION
In the litellm `ChatCompletionMessage` that we use a system message is
defined as follows:
```
class OpenAIChatCompletionSystemMessage(TypedDict, total=False):
    role: Required[Literal["system"]]
    content: Required[Union[str, List]]
    name: str
```

So content can either be a string or a list. Our secret encryption code only
handled the string case. Since both cases will properly be handled by the
soon-to-be-coming rewrite, let's just add a workaround so that e.g. Cline with
Anthropic keeps working.

With the no-more-litellm branch, everything works as expected.

Fixes: #1207
