### PR TITLE
Run make all to reformat code automatically

### DIFF
--- a/src/codegate/pipeline/pii/analyzer.py
+++ b/src/codegate/pipeline/pii/analyzer.py
@@ -1,10 +1,9 @@
-from typing import Any, List, Optional
+from typing import List, Optional
 
 import structlog
 from presidio_analyzer import AnalyzerEngine
 from presidio_anonymizer import AnonymizerEngine
 
-from codegate.db.models import AlertSeverity
 from codegate.pipeline.base import PipelineContext
 from codegate.pipeline.sensitive_data.session_store import SessionStore
 

--- a/src/codegate/pipeline/pii/pii.py
+++ b/src/codegate/pipeline/pii/pii.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, List, Optional, Tuple
-import uuid
 
 import regex as re
 import structlog

--- a/src/codegate/pipeline/sensitive_data/manager.py
+++ b/src/codegate/pipeline/sensitive_data/manager.py
@@ -1,7 +1,8 @@
-import json
 from typing import Dict, Optional
+
 import pydantic
 import structlog
+
 from codegate.pipeline.sensitive_data.session_store import SessionStore
 
 logger = structlog.get_logger("codegate")

--- a/src/codegate/pipeline/sensitive_data/session_store.py
+++ b/src/codegate/pipeline/sensitive_data/session_store.py
@@ -1,5 +1,5 @@
-from typing import Dict, Optional
 import uuid
+from typing import Dict, Optional
 
 
 class SessionStore:

--- a/tests/pipeline/pii/test_analyzer.py
+++ b/tests/pipeline/pii/test_analyzer.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from presidio_analyzer import RecognizerResult
 
 from codegate.pipeline.pii.analyzer import PiiAnalyzer
 

--- a/tests/pipeline/sensitive_data/test_manager.py
+++ b/tests/pipeline/sensitive_data/test_manager.py
@@ -1,6 +1,7 @@
-import json
 from unittest.mock import MagicMock, patch
+
 import pytest
+
 from codegate.pipeline.sensitive_data.manager import SensitiveData, SensitiveDataManager
 from codegate.pipeline.sensitive_data.session_store import SessionStore
 

--- a/tests/pipeline/sensitive_data/test_session_store.py
+++ b/tests/pipeline/sensitive_data/test_session_store.py
@@ -1,5 +1,5 @@
-import uuid
 import pytest
+
 from codegate.pipeline.sensitive_data.session_store import SessionStore
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,7 +14,6 @@ from uvicorn.config import Config as UvicornConfig
 
 from codegate import __version__
 from codegate.pipeline.factory import PipelineFactory
-from codegate.pipeline.sensitive_data.manager import SensitiveDataManager
 from codegate.providers.registry import ProviderRegistry
 from codegate.server import init_app
 from src.codegate.cli import UvicornServer, cli


### PR DESCRIPTION
I don't know why our lint CI step doesn't catch this (it did slap me the
other day for other reasons, so it is working), but running `make all`
produced a bunch of reformats.
