### PR TITLE
chore: handle DASHBOARD_API_BASE_URL env at docker run time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,7 @@ FROM python:3.12-slim AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgomp1 \
     nginx \
+    gettext-base \  
     && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user
@@ -81,6 +82,7 @@ RUN useradd -m -u 1000 -r codegate
 # Set permissions for user codegate to run nginx
 RUN chown -R codegate /var/lib/nginx && \
     chown -R codegate /var/log/nginx && \
+    chown -R codegate /etc/nginx && \
     chown -R codegate /run
 
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -28,11 +28,10 @@ generate_certs() {
 
 # Function to start Nginx server for the dashboard
 start_dashboard() {
-    if [ -n "${DASHBOARD_BASE_URL}" ]; then
-	echo "Overriding dashboard url with $DASHBOARD_BASE_URL"
-	sed -ibck "s|http://localhost:8989|http://$DASHBOARD_BASE_URL:8989|g" /var/www/html/assets/*.js
-    fi
     echo "Starting the dashboard..."
+    
+    envsubst '${DASHBOARD_API_BASE_URL}' < /var/www/html/index.html > /var/www/html/index.html.tmp && mv /var/www/html/index.html.tmp /var/www/html/index.html
+
     nginx -g 'daemon off;' &
 }
 


### PR DESCRIPTION
In order to allow the users to specify the dashboard base api url (by default it is `http://localhost:8989`) we can add a docker env `DASHBOARD_API_BASE_URL` that the users can use to set dashboard api base url in the UI.
Rather than using sed for replace the env var in the js file, we can use `envsubst` through the index.html that includes the env var used in the UI for handle the API requests.

If custom env var, `DASHBOARD_API_BASE_URL`, miss the default base path,`http://localhost:8989`, will be used.

The [UI](https://github.com/stacklok/codegate-ui/pull/374) is already updated and able to handle the env var.
All the changes are backward compatible.

Discord [thread](https://discord.com/channels/1184987096302239844/1339150207979360307)

**Custom dashboard api base url**
Set the env DASHBOARD_API_BASE_URL="https://api.example.com", all the request will have `https://api.example.com` as base path.

https://github.com/user-attachments/assets/fc54619c-db55-43ce-aa93-176efa64909a

