### PR TITLE
Created necessary methods for Persona CRUD

### DIFF
--- a/src/codegate/api/v1_models.py
+++ b/src/codegate/api/v1_models.py
@@ -315,3 +315,19 @@ class ModelByProvider(pydantic.BaseModel):
 
     def __str__(self):
         return f"{self.provider_name} / {self.name}"
+
+
+class PersonaRequest(pydantic.BaseModel):
+    """
+    Model for creating a new Persona.
+    """
+    name: str
+    description: str
+
+
+class PersonaUpdateRequest(pydantic.BaseModel):
+    """
+    Model for updating a Persona.
+    """
+    new_name: str
+    new_description: str

--- a/src/codegate/api/v1_models.py
+++ b/src/codegate/api/v1_models.py
@@ -321,6 +321,7 @@ class PersonaRequest(pydantic.BaseModel):
     """
     Model for creating a new Persona.
     """
+
     name: str
     description: str
 
@@ -329,5 +330,6 @@ class PersonaUpdateRequest(pydantic.BaseModel):
     """
     Model for updating a Persona.
     """
+
     new_name: str
     new_description: str

--- a/src/codegate/db/models.py
+++ b/src/codegate/db/models.py
@@ -252,7 +252,7 @@ def nd_array_custom_before_validator(x):
 
 def nd_array_custom_serializer(x):
     # custome serialization logic
-    return str(x)
+    return x
 
 
 # Pydantic doesn't support numpy arrays out of the box hence we need to construct a custom type.


### PR DESCRIPTION
Closes: #1219

Some changes in this PR
- Renamed Semantic Router to PersonaManager: The motivation is that the only semantic routing we're doing is based on persona. So lets just call it that wat
- Created update and delete methods for Persona
- Added tests for the whole Persona CRUD