### PR TITLE
Add `instance` table along with init code.

### DIFF
--- a/migrations/versions/2025_03_05_2126-e4c05d7591a8_add_installation_table.py
+++ b/migrations/versions/2025_03_05_2126-e4c05d7591a8_add_installation_table.py
@@ -1,0 +1,63 @@
+"""add installation table
+
+Revision ID: e4c05d7591a8
+Revises: 3ec2b4ab569c
+Create Date: 2025-03-05 21:26:19.034319+00:00
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e4c05d7591a8"
+down_revision: Union[str, None] = "3ec2b4ab569c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("BEGIN TRANSACTION;")
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS instance (
+          id TEXT PRIMARY KEY,  -- UUID stored as TEXT
+          created_at DATETIME NOT NULL
+        );
+        """
+    )
+
+    op.execute(
+        """
+        -- The following trigger prevents multiple insertions in the
+        -- instance table. It is safe since the dimension of the table
+        -- is fixed.
+
+        CREATE TRIGGER single_instance
+        BEFORE INSERT ON instance
+        WHEN (SELECT COUNT(*) FROM instance) >= 1
+        BEGIN
+          SELECT RAISE(FAIL, 'only one instance!');
+        END;
+        """
+    )
+
+    # Finish transaction
+    op.execute("COMMIT;")
+
+
+def downgrade() -> None:
+    op.execute("BEGIN TRANSACTION;")
+
+    op.execute(
+        """
+        DROP TABLE instance;
+        """
+    )
+
+    # Finish transaction
+    op.execute("COMMIT;")

--- a/src/codegate/cli.py
+++ b/src/codegate/cli.py
@@ -14,7 +14,11 @@ from uvicorn.server import Server
 from codegate.ca.codegate_ca import CertificateAuthority
 from codegate.codegate_logging import LogFormat, LogLevel, setup_logging
 from codegate.config import Config, ConfigurationError
-from codegate.db.connection import init_db_sync, init_session_if_not_exists
+from codegate.db.connection import (
+    init_db_sync,
+    init_session_if_not_exists,
+    init_instance,
+)
 from codegate.pipeline.factory import PipelineFactory
 from codegate.pipeline.sensitive_data.manager import SensitiveDataManager
 from codegate.providers import crud as provendcrud
@@ -318,6 +322,7 @@ def serve(  # noqa: C901
         logger = structlog.get_logger("codegate").bind(origin="cli")
 
         init_db_sync(cfg.db_path)
+        init_instance(cfg.db_path)
         init_session_if_not_exists(cfg.db_path)
 
         # Check certificates and create CA if necessary

--- a/src/codegate/db/models.py
+++ b/src/codegate/db/models.py
@@ -120,6 +120,11 @@ class Session(BaseModel):
     last_update: datetime.datetime
 
 
+class Instance(BaseModel):
+    id: str
+    created_at: datetime.datetime
+
+
 # Models for select queries
 
 


### PR DESCRIPTION
This change adds an `instance` table containing the minimum set of details about codegate. We might want to add more details in the future.

The table must contain only a single record at any time. To guarantee that, a trigger is added that prevents inserts beyond the first record.

Finally, code performing the initialization is added to the `serve` command.
