### PR TITLE
Allow for dynamic workspace selection for muxing

### DIFF
--- a/migrations/versions/2025_03_05_2126-e4c05d7591a8_add_installation_table.py
+++ b/migrations/versions/2025_03_05_2126-e4c05d7591a8_add_installation_table.py
@@ -9,8 +9,6 @@ Create Date: 2025-03-05 21:26:19.034319+00:00
 from typing import Sequence, Union
 
 from alembic import op
-import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
 revision: str = "e4c05d7591a8"

--- a/src/codegate/cli.py
+++ b/src/codegate/cli.py
@@ -16,8 +16,8 @@ from codegate.codegate_logging import LogFormat, LogLevel, setup_logging
 from codegate.config import Config, ConfigurationError
 from codegate.db.connection import (
     init_db_sync,
-    init_session_if_not_exists,
     init_instance,
+    init_session_if_not_exists,
 )
 from codegate.pipeline.factory import PipelineFactory
 from codegate.pipeline.sensitive_data.manager import SensitiveDataManager

--- a/src/codegate/db/connection.py
+++ b/src/codegate/db/connection.py
@@ -617,7 +617,7 @@ class DbRecorder(DbCodeGate):
             await self._execute_with_no_return(sql, instance.model_dump())
         except IntegrityError as e:
             logger.debug(f"Exception type: {type(e)}")
-            raise AlreadyExistsError(f"Instance already initialized.")
+            raise AlreadyExistsError("Instance already initialized.")
 
 
 class DbReader(DbCodeGate):


### PR DESCRIPTION
This allows for the muxing endpoint to detect the `X-CodeGate-Workspace`
header in requests. This will allow CodeGate to search for that
workspace and use it's routing configuration explicitly.

If the a workspace is requested and it does not exist, a warning will be
issued and the active workspace will be defaulted to.

The use case for this is for background agents to be able to select a
relevant workspace and not need to disrupt the user's IDE session.

Note that this is not a persistent session and merely a dynamic runtime
setting.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
