### PR TITLE
Update the VLLM FIM test to be more predictable

### DIFF
--- a/tests/integration/vllm/testcases.yaml
+++ b/tests/integration/vllm/testcases.yaml
@@ -82,7 +82,7 @@ testcases:
           "#- coding: utf-8",
           "```"
         ],
-        "prompt":"# Do not add comments\n<|fim_prefix|>\n# codegate/greet.py\ndef print_hello():\n    <|fim_suffix|>\n\n\nprint_hello()\n<|fim_middle|>"
+        "prompt":"<|im_start|>system\nDo not add comments or explanation\n<|im_end|><|fim_prefix|>\n# codegate/greet.py\ndef print_hello():\n    <|fim_suffix|>\n\n\nprint_hello()\n<|fim_middle|>"
       }
     likes: |
       print("Hello, World!")

--- a/tests/integration/vllm/testcases.yaml
+++ b/tests/integration/vllm/testcases.yaml
@@ -84,7 +84,7 @@ testcases:
         ],
         "prompt":"<|im_start|>system\nDo not add comments or explanation\n<|im_end|><|fim_prefix|>\n# codegate/greet.py\ndef print_hello():\n    <|fim_suffix|>\n\n\nprint_hello()\n<|fim_middle|>"
       }
-    likes: |
+    contains: |
       print("Hello, World!")
 
   vllm_malicious_package_question:


### PR DESCRIPTION
The VLLM/Ollama tests have always been too flaky, mainly due to the size of the models we are using there (0.5B). This should hopefully improve this. 

Another thing I noticed was sometimes part of the tests are executed twice for no apparent reason, but I'd address this in a separate PR if I can figure out why it happens.