### PR TITLE
Fix Anthropic FIM with muxing.

### DIFF
--- a/src/codegate/muxing/router.py
+++ b/src/codegate/muxing/router.py
@@ -138,7 +138,15 @@ class MuxRouter:
             # TODO this should be improved
             match model_route.endpoint.provider_type:
                 case ProviderType.anthropic:
-                    if is_fim_request:
+                    # Note: despite `is_fim_request` being true, our
+                    # integration tests query the `/chat/completions`
+                    # endpoint, which causes the
+                    # `anthropic_from_legacy_openai` to incorrectly
+                    # populate the struct.
+                    #
+                    # Checking for the actual type is a much more
+                    # reliable way of determining the right mapper.
+                    if isinstance(parsed, openai.LegacyCompletionRequest):
                         completion_function = anthropic.acompletion
                         from_openai = anthropic_from_legacy_openai
                         to_openai = anthropic_to_legacy_openai

--- a/src/codegate/providers/ollama/completion_handler.py
+++ b/src/codegate/providers/ollama/completion_handler.py
@@ -73,7 +73,7 @@ async def _ollama_dispatcher(  # noqa: C901
         stream = openai_stream_generator(prepend(first, stream))
 
     if isinstance(first, OpenAIChatCompletion):
-        stream = openai_single_response_generator(first, stream)
+        stream = openai_single_response_generator(first)
 
     async for item in stream:
         yield item

--- a/src/codegate/types/anthropic/__init__.py
+++ b/src/codegate/types/anthropic/__init__.py
@@ -1,6 +1,8 @@
 from ._generators import (
     acompletion,
     message_wrapper,
+    single_message,
+    single_response,
     stream_generator,
 )
 from ._request_models import (
@@ -49,6 +51,8 @@ from ._response_models import (
 __all__ = [
     "acompletion",
     "message_wrapper",
+    "single_message",
+    "single_response",
     "stream_generator",
     "AssistantMessage",
     "CacheControl",

--- a/src/codegate/types/anthropic/_request_models.py
+++ b/src/codegate/types/anthropic/_request_models.py
@@ -155,6 +155,7 @@ ToolChoiceType = Union[
     Literal["auto"],
     Literal["any"],
     Literal["tool"],
+    Literal["none"],
 ]
 
 

--- a/src/codegate/types/generators.py
+++ b/src/codegate/types/generators.py
@@ -1,37 +1,27 @@
-import os
 from typing import (
-    Any,
-    AsyncIterator,
+    Callable,
 )
 
-import pydantic
 import structlog
 
 logger = structlog.get_logger("codegate")
 
 
-# Since different providers typically use one of these formats for streaming
-# responses, we have a single stream generator for each format that is then plugged
-# into the adapter.
+def completion_handler_replacement(
+    completion_handler: Callable,
+):
+    async def _inner(
+        request,
+        base_url,
+        api_key,
+        stream=None,
+        is_fim_request=None,
+    ):
+        # Execute e.g. acompletion from Anthropic types
+        return completion_handler(
+            request,
+            api_key,
+            base_url,
+        )
 
-
-async def sse_stream_generator(stream: AsyncIterator[Any]) -> AsyncIterator[str]:
-    """OpenAI-style SSE format"""
-    try:
-        async for chunk in stream:
-            if isinstance(chunk, pydantic.BaseModel):
-                # alternatively we might want to just dump the whole object
-                # this might even allow us to tighten the typing of the stream
-                chunk = chunk.model_dump_json(exclude_none=True, exclude_unset=True)
-            try:
-                if os.getenv("CODEGATE_DEBUG_OPENAI") is not None:
-                    print(chunk)
-                yield f"data: {chunk}\n\n"
-            except Exception as e:
-                logger.error("failed generating output payloads", exc_info=e)
-                yield f"data: {str(e)}\n\n"
-    except Exception as e:
-        logger.error("failed generating output payloads", exc_info=e)
-        yield f"data: {str(e)}\n\n"
-    finally:
-        yield "data: [DONE]\n\n"
+    return _inner

--- a/src/codegate/types/ollama/_generators.py
+++ b/src/codegate/types/ollama/_generators.py
@@ -23,7 +23,7 @@ async def stream_generator(
     try:
         async for chunk in stream:
             try:
-                body = chunk.model_dump_json(exclude_none=True, exclude_unset=True)
+                body = chunk.model_dump_json(exclude_unset=True)
                 data = f"{body}\n"
 
                 if os.getenv("CODEGATE_DEBUG_OLLAMA") is not None:

--- a/src/codegate/types/openai/_generators.py
+++ b/src/codegate/types/openai/_generators.py
@@ -50,25 +50,12 @@ async def stream_generator(stream: AsyncIterator[StreamingChatCompletion]) -> As
 
 async def single_response_generator(
     first: ChatCompletion,
-    stream: AsyncIterator[ChatCompletion],
 ) -> AsyncIterator[ChatCompletion]:
     """Wraps a single response object in an AsyncIterator. This is
     meant to be used for non-streaming responses.
 
     """
     yield first.model_dump_json(exclude_none=True, exclude_unset=True)
-
-    # Note: this async for loop is necessary to force Python to return
-    # an AsyncIterator. This is necessary because of the wiring at the
-    # Provider level expecting an AsyncIterator rather than a single
-    # response payload.
-    #
-    # Refactoring this means adding a code path specific for when we
-    # expect single response payloads rather than an SSE stream.
-    async for item in stream:
-        if item:
-            logger.error("no further items were expected", item=item)
-        yield item.model_dump_json(exclude_none=True, exclude_unset=True)
 
 
 async def completions_streaming(request, api_key, base_url):


### PR DESCRIPTION
In the context of muxing, the code determining which mapper to use when receiving requests to be routed towards Anthropic was relying in `is_fim_request` only, and was not taking into account if the actual endpoint receiving the request was the legacy one (i.e. `/completions`) or the current one (i.e. `/chat/completions`). This caused the use of the wrong mapper, which led to an empty text content for the FIM request.

A better way to determine which mapper to use is looking at the effective type, since that's the real source of truth for the translation.