### PR TITLE
Fix: fetching codegate env var logic

### DIFF
--- a/src/codegate/updates/client.py
+++ b/src/codegate/updates/client.py
@@ -9,8 +9,7 @@ logger = structlog.get_logger("codegate")
 
 __update_client_singleton = None
 
-is_dev_env = bool(os.environ.get("CODEGATE_DEV_ENV"))
-
+is_dev_env = os.environ.get("CODEGATE_DEV_ENV", "false").lower() == "true"
 
 # Enum representing whether the request is coming from the front-end or the back-end.
 class Origin(Enum):


### PR DESCRIPTION
This is a fix for https://github.com/stacklok/codegate/pull/1330

https://stackoverflow.com/a/65640689

Tested this locally


```
2025-04-01 23:17:16 Initializing entrypoint script...
2025-04-01 23:17:16 Backup path or mode not provided. Skipping restore.
2025-04-01 23:17:16 Generating certificates...
2025-04-01 23:17:18 /usr/local/lib/python3.12/site-packages/pydantic/_internal/_fields.py:192: UserWarning: Field name "schema" in "JsonSchema" shadows an attribute in parent "BaseModel"
2025-04-01 23:17:18   warnings.warn(
2025-04-01 23:17:18 Starting the dashboard...
2025-04-01 23:17:18 Starting the application with args: --port 8989 --host 0.0.0.0 --model-base-path /app/codegate_volume/models --db-path /app/codegate_volume/db/codegate.db --vec-db-path /app/sqlite_data/vectordb.db --ollama-url http://host.docker.internal:11434 --lm-studio-url http://host.docker.internal:1234 --log-level WARNING --log-format TEXT
2025-04-01 23:17:20 /usr/local/lib/python3.12/site-packages/pydantic/_internal/_fields.py:192: UserWarning: Field name "schema" in "JsonSchema" shadows an attribute in parent "BaseModel"
2025-04-01 23:17:20   warnings.warn(
2025-04-01 23:17:21 alembic
2025-04-01 23:17:21 is_dev_env: True
2025-04-01 23:17:21 Existing Certificates are already present.
2025-04-01 23:17:21 2025-04-01T20:17:21.687690Z [warning  ] A new version of CodeGate is available: v0.1.30 lineno=33 module=scheduled pathname=/app/src/codegate/updates/scheduled.py
```