### PR TITLE
Fix Anthropic serialization bug.

### DIFF
--- a/src/codegate/types/anthropic/_generators.py
+++ b/src/codegate/types/anthropic/_generators.py
@@ -117,7 +117,7 @@ async def acompletion(request, api_key, base_url):
         "accept": "application/json",
         "content-type": "application/json",
     }
-    payload = request.json(exclude_defaults=True)
+    payload = request.model_dump_json(exclude_none=True, exclude_unset=True)
 
     if os.getenv("CODEGATE_DEBUG_ANTHROPIC") is not None:
         print(payload)


### PR DESCRIPTION
Excluding defaults caused `tool_choice` to become an empty dictionary in case `{"type": "auto"}` was explicitly provider by the client.

Also, we were using the wrong method.