### PR TITLE
Add missing variable initialization.

### DIFF
--- a/src/codegate/providers/base.py
+++ b/src/codegate/providers/base.py
@@ -287,6 +287,7 @@ class BaseProvider(ABC):
             is_fim_request,
         )
 
+        provider_request = normalized_request  # default value
         if input_pipeline_result.request:
             provider_request = self._input_normalizer.denormalize(input_pipeline_result.request)
         if is_fim_request:


### PR DESCRIPTION
Under some weird circumstance, the `if` statements after the newly added line are both evaluating to `False`, causing the variable `provider_request` to never be initialized.

This initializes the variable to a reasonable default value, but I'm not 100% sure it solves the problem.

Fixes #1345