### PR TITLE
Resolve Pydantic deprecation warnings

### DIFF
--- a/src/codegate/types/anthropic/_generators.py
+++ b/src/codegate/types/anthropic/_generators.py
@@ -28,7 +28,7 @@ async def stream_generator(stream: AsyncIterator[Any]) -> AsyncIterator[str]:
     try:
         async for chunk in stream:
             try:
-                body = chunk.json(exclude_unset=True)
+                body = chunk.model_dump_json(exclude_unset=True)
             except Exception as e:
                 logger.error("failed serializing payload", exc_info=e)
                 err = MessageError(
@@ -38,7 +38,7 @@ async def stream_generator(stream: AsyncIterator[Any]) -> AsyncIterator[str]:
                         message=str(e),
                     ),
                 )
-                body = err.json(exclude_unset=True)
+                body = err.model_dump_json(exclude_unset=True)
                 yield f"event: error\ndata: {body}\n\n"
 
             data = f"event: {chunk.type}\ndata: {body}\n\n"
@@ -56,7 +56,7 @@ async def stream_generator(stream: AsyncIterator[Any]) -> AsyncIterator[str]:
                 message=str(e),
             ),
         )
-        body = err.json(exclude_unset=True)
+        body = err.model_dump_json(exclude_unset=True)
         yield f"event: error\ndata: {body}\n\n"
 
 


### PR DESCRIPTION
# PR Summary
This small PR resolves the Pydantic deprecation warnings:
```python
/home/runner/work/codegate/codegate/src/codegate/types/anthropic/_generators.py:59: PydanticDeprecatedSince20: The `json` method is deprecated; use `model_dump_json` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
```